### PR TITLE
Collapse consecutive wildcards in query parser

### DIFF
--- a/Octans.Core/Querying/QueryParser.cs
+++ b/Octans.Core/Querying/QueryParser.cs
@@ -84,7 +84,9 @@ public class QueryParser
         // Remove leading/trailing whitespace and collapse multiple consecutive whitespace.
         var cleaned = Regex.Replace(raw.Trim(), @"\s+", " ");
 
-        // TODO: this should also replace multiple consecutive wildcards with just one.
+        // Replace multiple consecutive wildcards with just one.
+        var wildcard = Regex.Escape(PredicateConstants.Wildcard.ToString());
+        cleaned = Regex.Replace(cleaned, $"{wildcard}{{2,}}", PredicateConstants.Wildcard.ToString());
 
         var exclusive = cleaned.StartsWith(PredicateConstants.Negation);
 

--- a/Octans.Tests/Querying/QueryParserTests.cs
+++ b/Octans.Tests/Querying/QueryParserTests.cs
@@ -139,4 +139,15 @@ public class QueryParserTests
         inner.Predicates.Last().Should().Match<TagPredicate>(tp =>
                 tp.NamespacePattern == "character" && tp.SubtagPattern == "luigi" && !tp.IsExclusive);
     }
+
+    [Fact]
+    public void Parse_MultipleWildcards_CollapsesToSingleWildcard()
+    {
+        var result = _parser.Parse(["character:**samus**"]);
+
+        var tag = result.OfType<TagPredicate>().Single();
+
+        tag.NamespacePattern.Should().Be("character");
+        tag.SubtagPattern.Should().Be("*samus*");
+    }
 }


### PR DESCRIPTION
## Summary
- Collapse consecutive `*` wildcards into a single wildcard when parsing queries
- Add unit test for wildcard collapsing in `QueryParser`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b937a63c888331991d996fb9cb1fb4