### PR TITLE
Upload coverage report in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,15 @@ jobs:
       
     - name: Build
       run: dotnet build --no-restore
-      
+
     - name: Test
-      run: dotnet test --no-build --verbosity normal --collect:"Code Coverage"
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: '**/TestResults/*/coverage.cobertura.xml'
       
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- collect cross-platform code coverage during tests
- upload coverage.cobertura.xml as a workflow artifact

## Testing
- `dotnet test --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_68bbfd3ce7e08331a5bfda4b0a4e49e8