### PR TITLE
feat: add settings infrastructure

### DIFF
--- a/Octans.Client/Components/Settings/SettingItem.razor
+++ b/Octans.Client/Components/Settings/SettingItem.razor
@@ -1,0 +1,49 @@
+@using Octans.Client.Components.Settings
+@implements IDisposable
+
+<div class="setting-item" @ref="_element">
+    <label>@Name</label>
+    @Control
+    @if (!string.IsNullOrEmpty(Description))
+    {
+        <p>@Description</p>
+    }
+</div>
+
+@code {
+    [CascadingParameter] public SettingsContext Context { get; set; } = null!;
+    [CascadingParameter] public SettingsPageDescriptor Page { get; set; } = null!;
+
+    [Parameter] public string Name { get; set; } = string.Empty;
+    [Parameter] public string? Description { get; set; }
+    [Parameter] public IEnumerable<string> Tags { get; set; } = Enumerable.Empty<string>();
+    [Parameter] public RenderFragment? Control { get; set; }
+
+    private ElementReference _element;
+    private SettingDescriptor? _descriptor;
+
+    protected override void OnInitialized()
+    {
+        _descriptor = new SettingDescriptor(Name, Page, Tags, () => _element.FocusAsync().AsTask());
+        Context.RegisterSetting(_descriptor);
+    }
+
+    public void Dispose()
+    {
+        if (_descriptor is not null)
+        {
+            Context.UnregisterSetting(_descriptor);
+        }
+    }
+}
+
+<style>
+    .setting-item {
+        margin-bottom: 1rem;
+    }
+
+    .setting-item label {
+        display: block;
+        font-weight: bold;
+    }
+</style>

--- a/Octans.Client/Components/Settings/Settings.razor
+++ b/Octans.Client/Components/Settings/Settings.razor
@@ -1,0 +1,109 @@
+@page "/settings"
+@using Octans.Client.Components.Settings
+@rendermode InteractiveServer
+
+<CascadingValue Value="_context">
+    <div class="settings-layout">
+        <input class="settings-search" @bind="_searchText" placeholder="Search settings..." />
+        <div class="settings-body">
+            <SettingsSidebar Pages="_context.Pages" ActivePage="_activePage" OnSelectPage="SelectPage" />
+            <div class="settings-content">
+                <CascadingValue Value="_activePage">
+                    <SettingsPage Title="Import">
+                        <SettingItem Name="Import Source" Tags=@(new[] { "import" })>
+                            <Control>
+                                <input />
+                            </Control>
+                        </SettingItem>
+                    </SettingsPage>
+
+                    <SettingsPage Title="Tags">
+                        <SettingItem Name="Tag Colour" Tags=@(new[] { "colour", "tag" })>
+                            <Control>
+                                <input />
+                            </Control>
+                        </SettingItem>
+                    </SettingsPage>
+
+                    <SettingsPage Title="System">
+                        <SettingItem Name="Enable Logs" Tags=@(new[] { "log" })>
+                            <Control>
+                                <input type="checkbox" />
+                            </Control>
+                        </SettingItem>
+                    </SettingsPage>
+                </CascadingValue>
+            </div>
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(_searchText))
+        {
+            <ul class="settings-search-results">
+                @foreach (var result in _context.Search(_searchText))
+                {
+                    <li @onclick="@(() => NavigateTo(result))">@result.Name (@result.Page.Title)</li>
+                }
+            </ul>
+        }
+    </div>
+</CascadingValue>
+
+@code {
+    private readonly SettingsContext _context = new();
+    private SettingsPageDescriptor? _activePage;
+    private string _searchText = string.Empty;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender && _context.Pages.Count > 0 && _activePage is null)
+        {
+            _activePage = _context.Pages[0];
+            StateHasChanged();
+        }
+    }
+
+    private void SelectPage(SettingsPageDescriptor page)
+    {
+        _activePage = page;
+    }
+
+    private async Task NavigateTo(SettingDescriptor descriptor)
+    {
+        _activePage = descriptor.Page;
+        await descriptor.Focus();
+    }
+}
+
+<style>
+    .settings-layout {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    .settings-search {
+        margin-bottom: 1rem;
+        padding: 0.5rem;
+    }
+
+    .settings-body {
+        display: flex;
+        flex: 1;
+    }
+
+    .settings-content {
+        flex: 1;
+        padding: 1rem;
+    }
+
+    .settings-search-results {
+        list-style: none;
+        margin: 1rem 0 0 0;
+        padding: 0;
+    }
+
+    .settings-search-results li {
+        cursor: pointer;
+        padding: 0.25rem 0;
+    }
+</style>

--- a/Octans.Client/Components/Settings/SettingsContext.cs
+++ b/Octans.Client/Components/Settings/SettingsContext.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace Octans.Client.Components.Settings;
+
+public class SettingsContext
+{
+    private readonly List<SettingsPageDescriptor> _pages = new();
+    private readonly List<SettingDescriptor> _settings = new();
+
+    public IReadOnlyList<SettingsPageDescriptor> Pages => _pages;
+    public IReadOnlyList<SettingDescriptor> Settings => _settings;
+
+    public void RegisterPage(SettingsPageDescriptor descriptor) => _pages.Add(descriptor);
+
+    public void UnregisterPage(SettingsPageDescriptor descriptor) => _pages.Remove(descriptor);
+
+    public void RegisterSetting(SettingDescriptor descriptor) => _settings.Add(descriptor);
+
+    public void UnregisterSetting(SettingDescriptor descriptor) => _settings.Remove(descriptor);
+
+    public IEnumerable<SettingDescriptor> Search(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return Array.Empty<SettingDescriptor>();
+        }
+
+        var comparison = StringComparison.OrdinalIgnoreCase;
+        return _settings.Where(s => s.Name.Contains(query, comparison) ||
+                                    s.Tags.Any(t => t.Contains(query, comparison)));
+    }
+}
+
+public record SettingsPageDescriptor(string Title, string? Icon, RenderFragment PageContent);
+
+public record SettingDescriptor(string Name, SettingsPageDescriptor Page, IEnumerable<string> Tags, Func<Task> Focus);
+

--- a/Octans.Client/Components/Settings/SettingsPage.razor
+++ b/Octans.Client/Components/Settings/SettingsPage.razor
@@ -1,0 +1,27 @@
+@using Octans.Client.Components.Settings
+
+@if (IsActive)
+{
+    <CascadingValue Value="Descriptor">
+        @ChildContent
+    </CascadingValue>
+}
+
+@code {
+    [CascadingParameter] public SettingsContext Context { get; set; } = null!;
+    [CascadingParameter] public SettingsPageDescriptor? ActivePage { get; set; }
+
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string? Icon { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    public SettingsPageDescriptor Descriptor { get; private set; } = null!;
+
+    protected override void OnInitialized()
+    {
+        Descriptor = new SettingsPageDescriptor(Title, Icon, ChildContent ?? (_ => { }));
+        Context.RegisterPage(Descriptor);
+    }
+
+    private bool IsActive => ActivePage == Descriptor;
+}

--- a/Octans.Client/Components/Settings/SettingsSidebar.razor
+++ b/Octans.Client/Components/Settings/SettingsSidebar.razor
@@ -1,0 +1,31 @@
+@using Octans.Client.Components.Settings
+
+<ul class="settings-sidebar">
+    @foreach (var p in Pages)
+    {
+        <li class="@(p == ActivePage ? "active" : null)" @onclick="@(() => OnSelectPage.InvokeAsync(p))">@p.Title</li>
+    }
+</ul>
+
+@code {
+    [Parameter] public IEnumerable<SettingsPageDescriptor> Pages { get; set; } = Enumerable.Empty<SettingsPageDescriptor>();
+    [Parameter] public SettingsPageDescriptor? ActivePage { get; set; }
+    [Parameter] public EventCallback<SettingsPageDescriptor> OnSelectPage { get; set; }
+}
+
+<style>
+    .settings-sidebar {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .settings-sidebar li {
+        cursor: pointer;
+        padding: 0.5rem 1rem;
+    }
+
+    .settings-sidebar li.active {
+        font-weight: bold;
+    }
+</style>


### PR DESCRIPTION
## Summary
- scaffold settings page with sidebar and search
- implement context registration for pages and items
- add SettingItem, SettingsPage, SettingsSidebar components

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2c356dc48331b8d1080f7d560ae1