### PR TITLE
fix: register settings on inactive pages

### DIFF
--- a/Octans.Client/Components/Settings/SettingsPage.razor
+++ b/Octans.Client/Components/Settings/SettingsPage.razor
@@ -1,11 +1,10 @@
 @using Octans.Client.Components.Settings
 
-@if (IsActive)
-{
-    <CascadingValue Value="Descriptor">
+<CascadingValue Value="Descriptor">
+    <div hidden="@(!IsActive)">
         @ChildContent
-    </CascadingValue>
-}
+    </div>
+</CascadingValue>
 
 @code {
     [CascadingParameter] public SettingsContext Context { get; set; } = null!;


### PR DESCRIPTION
## Summary
- render SettingsPage content while hidden to register settings on inactive pages

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3b3ab3a48331b310b4dc495d0c41