### PR TITLE
Introduce repository model and background filter processing

### DIFF
--- a/Octans.Data/Migrations/20250906122616_AddRepositories.Designer.cs
+++ b/Octans.Data/Migrations/20250906122616_AddRepositories.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Octans.Core.Models;
 
@@ -10,9 +11,11 @@ using Octans.Core.Models;
 namespace Octans.Server.Migrations
 {
     [DbContext(typeof(ServerDbContext))]
-    partial class ServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250906122616_AddRepositories")]
+    partial class AddRepositories
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/Octans.Data/Migrations/20250906122616_AddRepositories.cs
+++ b/Octans.Data/Migrations/20250906122616_AddRepositories.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Octans.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepositories : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Repositories",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Repositories", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Repositories",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Inbox" },
+                    { 2, "Archive" },
+                    { 3, "Trash" }
+                });
+
+            migrationBuilder.AddColumn<int>(
+                name: "RepositoryId",
+                table: "Hashes",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Hashes_RepositoryId",
+                table: "Hashes",
+                column: "RepositoryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Hashes_Repositories_RepositoryId",
+                table: "Hashes",
+                column: "RepositoryId",
+                principalTable: "Repositories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Hashes_Repositories_RepositoryId",
+                table: "Hashes");
+
+            migrationBuilder.DropTable(
+                name: "Repositories");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Hashes_RepositoryId",
+                table: "Hashes");
+
+            migrationBuilder.DropColumn(
+                name: "RepositoryId",
+                table: "Hashes");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Repository` entity and link `HashItem` to a repository
- seed built-in repositories and register a background worker to move items between them
- wire gallery filter results to a channel processed in batches
- add migration adding `RepositoryId` column and a `Repositories` table

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4b239de88331845cfe11f9a4802b