### PR TITLE
Filter out judged images in gallery

### DIFF
--- a/Octans.Client/Components/Gallery/GalleryViewmodel.cs
+++ b/Octans.Client/Components/Gallery/GalleryViewmodel.cs
@@ -216,6 +216,14 @@ public sealed class GalleryViewmodel(
 
             await repositoryChannel.WriteAsync(new(hex, destination));
         }
+
+        ImageUrls.RemoveAll(url =>
+            result.Choices.TryGetValue(url, out var choice) &&
+            choice == ImageViewer.FilterChoice.Delete);
+
+        await storage.ToSessionAsync("gallery", "gallery-images", ImageUrls);
+
+        await NotifyStateChanged();
     }
 
     public async ValueTask DisposeAsync()

--- a/Octans.Tests/Viewmodels/GalleryViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/GalleryViewmodelTests.cs
@@ -137,6 +137,26 @@ public class GalleryViewmodelTests
         Assert.Contains(items, r => r is {Hash: "01234567", Destination: RepositoryType.Trash});
     }
 
+    [Fact]
+    public async Task OnFilterComplete_filters_out_trashed_images_only()
+    {
+        _sut.ImageUrls.AddRange(Expected);
+
+        var result = new ImageViewer.FilterResult
+        {
+            Choices = new()
+            {
+                ["/media/DEADBEEF"] = ImageViewer.FilterChoice.Archive,
+                ["/media/01234567"] = ImageViewer.FilterChoice.Delete
+            }
+        };
+
+        await _sut.OnFilterComplete(result);
+
+        Assert.Contains("/media/DEADBEEF", _sut.ImageUrls);
+        Assert.DoesNotContain("/media/01234567", _sut.ImageUrls);
+    }
+
     private static async IAsyncEnumerable<HashItem> ReturnAsync(IEnumerable<HashItem> items)
     {
         foreach (var item in items)


### PR DESCRIPTION
## Summary
- Remove only trash-judged images from gallery view and keep archived items
- Add test ensuring only trashed images are removed after filtering

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68bd360912788331b0e06866b7e1f441