### PR TITLE
Add perceptual hashing service

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="NLua" Version="1.7.5" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageVersion Include="CoenM.ImageSharp.ImageHash" Version="1.3.6" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.15" />
     <PackageVersion Include="MimeDetective.InMemory.Ext" Version="1.0.5" />
     <PackageVersion Include="Dapper" Version="2.1.66" />

--- a/Octans.Core/Duplicates/IPerceptualHashProvider.cs
+++ b/Octans.Core/Duplicates/IPerceptualHashProvider.cs
@@ -1,0 +1,10 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Octans.Core.Duplicates;
+
+public interface IPerceptualHashProvider
+{
+    Task<ulong> GetHash(Stream imageStream, CancellationToken cancellationToken = default);
+}

--- a/Octans.Core/Duplicates/PerceptualHashProvider.cs
+++ b/Octans.Core/Duplicates/PerceptualHashProvider.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CoenM.ImageHash;
+using CoenM.ImageHash.HashAlgorithms;
+using Microsoft.Extensions.Logging;
+
+namespace Octans.Core.Duplicates;
+
+public class PerceptualHashProvider(ILogger<PerceptualHashProvider> logger) : IPerceptualHashProvider
+{
+    public Task<ulong> GetHash(Stream imageStream, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        using var scope = logger.BeginScope(new Dictionary<string, object?> { ["Service"] = nameof(PerceptualHashProvider) });
+        logger.LogDebug("Calculating perceptual hash");
+        var algorithm = new PerceptualHash();
+        var hash = algorithm.Hash(imageStream);
+        logger.LogDebug("Calculated perceptual hash {Hash}", hash);
+        return Task.FromResult(hash);
+    }
+}

--- a/Octans.Core/Octans.Core.csproj
+++ b/Octans.Core/Octans.Core.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
         <PackageReference Include="NLua"/>
         <PackageReference Include="SixLabors.ImageSharp"/>
+        <PackageReference Include="CoenM.ImageSharp.ImageHash" />
         <PackageReference Include="System.IO.Abstractions"/>
         <PackageReference Include="MimeDetective.InMemory.Ext"/>
         <PackageReference Include="Refit"/>


### PR DESCRIPTION
## Summary
- add perceptual hash interface and implementation for future duplicate detection
- use ImageHash library with structured logging
- reference CoenM.ImageSharp.ImageHash package

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4c7ab4988331808b39182a9b5946