### PR TITLE
Add EF models and migration for rating systems

### DIFF
--- a/Octans.Data/Migrations/20250907103211_AddRatingSystems.Designer.cs
+++ b/Octans.Data/Migrations/20250907103211_AddRatingSystems.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Octans.Core.Models;
 
@@ -10,9 +11,11 @@ using Octans.Core.Models;
 namespace Octans.Server.Migrations
 {
     [DbContext(typeof(ServerDbContext))]
-    partial class ServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250907103211_AddRatingSystems")]
+    partial class AddRatingSystems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/Octans.Data/Migrations/20250907103211_AddRatingSystems.cs
+++ b/Octans.Data/Migrations/20250907103211_AddRatingSystems.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Octans.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRatingSystems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RatingSystems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    Type = table.Column<int>(type: "INTEGER", nullable: false),
+                    MaxValue = table.Column<int>(type: "INTEGER", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RatingSystems", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "HashRatings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    HashId = table.Column<int>(type: "INTEGER", nullable: false),
+                    RatingSystemId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Value = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_HashRatings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_HashRatings_Hashes_HashId",
+                        column: x => x.HashId,
+                        principalTable: "Hashes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_HashRatings_RatingSystems_RatingSystemId",
+                        column: x => x.RatingSystemId,
+                        principalTable: "RatingSystems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                table: "RatingSystems",
+                columns: new[] { "Id", "MaxValue", "Name", "Type" },
+                values: new object[,]
+                {
+                    { 1, 1, "Favourites", 0 },
+                    { 2, 5, "Quality", 1 }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HashRatings_HashId",
+                table: "HashRatings",
+                column: "HashId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HashRatings_RatingSystemId",
+                table: "HashRatings",
+                column: "RatingSystemId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "HashRatings");
+
+            migrationBuilder.DropTable(
+                name: "RatingSystems");
+        }
+    }
+}

--- a/Octans.Data/Models/Hash.cs
+++ b/Octans.Data/Models/Hash.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using Octans.Core.Repositories;
+using Octans.Core.Models.Ratings;
 
 namespace Octans.Core.Models;
 
@@ -12,6 +13,7 @@ public class HashItem
     public DateTime? DeletedAt { get; set; }
     public int RepositoryId { get; set; } = (int)RepositoryType.Inbox;
     public Repository? Repository { get; init; }
+    public ICollection<HashRating> Ratings { get; set; } = new List<HashRating>();
 
     public bool IsDeleted() => DeletedAt is not null;
 }

--- a/Octans.Data/Models/Ratings/HashRating.cs
+++ b/Octans.Data/Models/Ratings/HashRating.cs
@@ -1,0 +1,11 @@
+using Octans.Core.Models;
+
+namespace Octans.Core.Models.Ratings;
+
+public class HashRating
+{
+    public int Id { get; set; }
+    public required HashItem Hash { get; set; }
+    public required RatingSystem RatingSystem { get; set; }
+    public int Value { get; set; }
+}

--- a/Octans.Data/Models/Ratings/RatingSystem.cs
+++ b/Octans.Data/Models/Ratings/RatingSystem.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octans.Core.Models.Ratings;
+
+public class RatingSystem
+{
+    [Key] public int Id { get; set; }
+    public required string Name { get; set; }
+    public RatingSystemType Type { get; set; }
+    public int? MaxValue { get; set; }
+    public ICollection<HashRating> HashRatings { get; set; } = new List<HashRating>();
+}

--- a/Octans.Data/Models/Ratings/RatingSystemType.cs
+++ b/Octans.Data/Models/Ratings/RatingSystemType.cs
@@ -1,0 +1,7 @@
+namespace Octans.Core.Models.Ratings;
+
+public enum RatingSystemType
+{
+    Toggle = 0,
+    Range = 1
+}

--- a/Octans.Data/Models/ServerDbContext.cs
+++ b/Octans.Data/Models/ServerDbContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Octans.Core.Downloaders;
 using Octans.Core.Models.Tagging;
 using Octans.Core.Repositories;
+using Octans.Core.Models.Ratings;
 
 namespace Octans.Core.Models;
 
@@ -20,15 +21,30 @@ public class ServerDbContext(DbContextOptions<ServerDbContext> context) : DbCont
     public virtual DbSet<DownloadStatus> DownloadStatuses { get; set; }
     public virtual DbSet<Provider> Providers { get; set; }
     public virtual DbSet<Subscription> Subscriptions { get; set; }
+    public virtual DbSet<RatingSystem> RatingSystems { get; set; }
+    public virtual DbSet<HashRating> HashRatings { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
 
+        modelBuilder.Entity<HashRating>()
+            .HasOne(r => r.Hash)
+            .WithMany(h => h.Ratings);
+
+        modelBuilder.Entity<HashRating>()
+            .HasOne(r => r.RatingSystem)
+            .WithMany(s => s.HashRatings);
+
         modelBuilder.Entity<Repository>().HasData(
             new Repository { Id = (int)RepositoryType.Inbox, Name = "Inbox" },
             new Repository { Id = (int)RepositoryType.Archive, Name = "Archive" },
             new Repository { Id = (int)RepositoryType.Trash, Name = "Trash" }
+        );
+
+        modelBuilder.Entity<RatingSystem>().HasData(
+            new RatingSystem { Id = 1, Name = "Favourites", Type = RatingSystemType.Toggle, MaxValue = 1 },
+            new RatingSystem { Id = 2, Name = "Quality", Type = RatingSystemType.Range, MaxValue = 5 }
         );
     }
 }


### PR DESCRIPTION
## Summary
- add rating system and hash rating EF models
- seed default Favourites toggle and Quality range systems
- create migration establishing rating tables

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5e7c13b48331a77616a587fe605e