### PR TITLE
Use ConcurrentDictionary for DownloadStateService

### DIFF
--- a/Octans.Core/Downloads/DownloadStateService.cs
+++ b/Octans.Core/Downloads/DownloadStateService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Octans.Core.Downloaders;
 using Octans.Core.Models;
+using System.Collections.Concurrent;
 
 namespace Octans.Core.Downloads;
 
@@ -40,8 +41,7 @@ public class DownloadStateService(
     ILogger<DownloadStateService> logger,
     IDbContextFactory<ServerDbContext> contextFactory) : IDownloadStateService
 {
-    private readonly Dictionary<Guid, DownloadStatus> _activeDownloads = new();
-    private readonly Lock _lock = new();
+    private readonly ConcurrentDictionary<Guid, DownloadStatus> _activeDownloads = new();
 
     public event EventHandler<DownloadStatusChangedEventArgs>? OnDownloadProgressChanged;
     public event EventHandler<DownloadsChangedEventArgs>? OnDownloadsChanged;
@@ -54,12 +54,9 @@ public class DownloadStateService(
             .Where(d => d.State != DownloadState.Completed && d.State != DownloadState.Canceled)
             .ToListAsync();
 
-        lock (_lock)
+        foreach (var status in statuses)
         {
-            foreach (var status in statuses)
-            {
-                _activeDownloads[status.Id] = status;
-            }
+            _activeDownloads[status.Id] = status;
         }
 
         OnDownloadsChanged?.Invoke(this, new()
@@ -70,107 +67,91 @@ public class DownloadStateService(
 
     public IReadOnlyList<DownloadStatus> GetAllDownloads()
     {
-        lock (_lock)
-        {
-            return _activeDownloads.Values.OrderByDescending(d => d.CreatedAt).ToList();
-        }
+        return _activeDownloads.Values.OrderByDescending(d => d.CreatedAt).ToList();
     }
 
     public DownloadStatus? GetDownloadById(Guid id)
     {
-        lock (_lock)
-        {
-            return _activeDownloads.TryGetValue(id, out var status) ? status : null;
-        }
+        return _activeDownloads.TryGetValue(id, out var status) ? status : null;
     }
 
     public void UpdateProgress(Guid id, long bytesDownloaded, long totalBytes, double speed)
     {
-        lock (_lock)
-        {
-            if (!_activeDownloads.TryGetValue(id, out var status)) return;
+        if (!_activeDownloads.TryGetValue(id, out var status)) return;
 
-            status.BytesDownloaded = bytesDownloaded;
-            status.TotalBytes = totalBytes;
-            status.CurrentSpeed = speed;
-            status.LastUpdated = DateTime.UtcNow;
+        status.BytesDownloaded = bytesDownloaded;
+        status.TotalBytes = totalBytes;
+        status.CurrentSpeed = speed;
+        status.LastUpdated = DateTime.UtcNow;
 
-            // Notify subscribers
-            OnDownloadProgressChanged?.Invoke(this, new() { Status = status });
-        }
+        // Notify subscribers
+        OnDownloadProgressChanged?.Invoke(this, new() { Status = status });
     }
 
     public void UpdateState(Guid id, DownloadState newState, string? errorMessage = null)
     {
-        lock (_lock)
+        if (!_activeDownloads.TryGetValue(id, out var status)) return;
+
+        status.State = newState;
+        status.LastUpdated = DateTime.UtcNow;
+
+        switch (newState)
         {
-            if (!_activeDownloads.TryGetValue(id, out var status)) return;
-
-            status.State = newState;
-            status.LastUpdated = DateTime.UtcNow;
-
-            switch (newState)
-            {
-                case DownloadState.InProgress:
-                    status.StartedAt ??= DateTime.UtcNow;
-                    break;
-                case DownloadState.Completed:
-                    status.CompletedAt = DateTime.UtcNow;
-                    break;
-                case DownloadState.Failed:
-                    status.ErrorMessage = errorMessage;
-                    break;
-            }
-
-            // Persist state change to database
-            Task.Run(async () =>
-            {
-                await using var db = await contextFactory.CreateDbContextAsync();
-
-                await using var scope = await db.Database.BeginTransactionAsync();
-
-                try
-                {
-                    var dbStatus = await db.DownloadStatuses.FindAsync(id);
-                    if (dbStatus != null)
-                    {
-                        dbStatus.State = status.State;
-                        dbStatus.BytesDownloaded = status.BytesDownloaded;
-                        dbStatus.TotalBytes = status.TotalBytes;
-                        dbStatus.LastUpdated = status.LastUpdated;
-                        dbStatus.StartedAt = status.StartedAt;
-                        dbStatus.CompletedAt = status.CompletedAt;
-                        dbStatus.ErrorMessage = status.ErrorMessage;
-
-                        await db.SaveChangesAsync();
-                        await scope.CommitAsync();
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Failed to persist download state change");
-                }
-            });
-
-            // Notify subscribers
-            OnDownloadProgressChanged?.Invoke(this, new() { Status = status });
-            OnDownloadsChanged?.Invoke(this, new()
-            {
-                AffectedDownloadId = id,
-                ChangeType = DownloadChangeType.Updated
-            });
+            case DownloadState.InProgress:
+                status.StartedAt ??= DateTime.UtcNow;
+                break;
+            case DownloadState.Completed:
+                status.CompletedAt = DateTime.UtcNow;
+                break;
+            case DownloadState.Failed:
+                status.ErrorMessage = errorMessage;
+                break;
         }
+
+        // Persist state change to database
+        Task.Run(async () =>
+        {
+            await using var db = await contextFactory.CreateDbContextAsync();
+
+            await using var scope = await db.Database.BeginTransactionAsync();
+
+            try
+            {
+                var dbStatus = await db.DownloadStatuses.FindAsync(id);
+                if (dbStatus != null)
+                {
+                    dbStatus.State = status.State;
+                    dbStatus.BytesDownloaded = status.BytesDownloaded;
+                    dbStatus.TotalBytes = status.TotalBytes;
+                    dbStatus.LastUpdated = status.LastUpdated;
+                    dbStatus.StartedAt = status.StartedAt;
+                    dbStatus.CompletedAt = status.CompletedAt;
+                    dbStatus.ErrorMessage = status.ErrorMessage;
+
+                    await db.SaveChangesAsync();
+                    await scope.CommitAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to persist download state change");
+            }
+        });
+
+        // Notify subscribers
+        OnDownloadProgressChanged?.Invoke(this, new() { Status = status });
+        OnDownloadsChanged?.Invoke(this, new()
+        {
+            AffectedDownloadId = id,
+            ChangeType = DownloadChangeType.Updated
+        });
     }
 
     public async Task AddOrUpdateDownloadAsync(DownloadStatus status)
     {
-        // Only lock the in-memory dictionary operation
-        lock (_lock)
-        {
-            _activeDownloads[status.Id] = status;
-        }
+        _activeDownloads[status.Id] = status;
 
-        // Perform database operations outside the lock
+        // Perform database operations
         try
         {
             await using var db = await contextFactory.CreateDbContextAsync();
@@ -203,12 +184,7 @@ public class DownloadStateService(
 
     public async Task RemoveDownloadAsync(Guid id)
     {
-        bool removed;
-
-        lock (_lock)
-        {
-            removed = _activeDownloads.Remove(id);
-        }
+        var removed = _activeDownloads.TryRemove(id, out _);
 
         if (!removed) return;
 


### PR DESCRIPTION
## Summary
- replace locked Dictionary with thread-safe ConcurrentDictionary in DownloadStateService
- remove explicit locking when tracking download states

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c3074f77b88331b59435001dfbaf83