### PR TITLE
Handle bandwidth throttling in download queue

### DIFF
--- a/Octans.Core/Downloads/DownloadDequeueResult.cs
+++ b/Octans.Core/Downloads/DownloadDequeueResult.cs
@@ -1,0 +1,6 @@
+using System;
+using Octans.Core.Downloaders;
+
+namespace Octans.Core.Downloads;
+
+public sealed record DownloadDequeueResult(QueuedDownload? Download, TimeSpan? SuggestedDelay);


### PR DESCRIPTION
## Summary
- Surface bandwidth limiter delays from the queue
- Download manager waits for suggested delay before retrying
- Add tests for bandwidth throttling scenarios

## Testing
- `dotnet test --logger "console;verbosity=normal" | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c310e8b7708331a72ea324a47a25ce