### PR TITLE
Add downloaders page

### DIFF
--- a/Octans.Client/Components/Downloads/Downloaders.razor
+++ b/Octans.Client/Components/Downloads/Downloaders.razor
@@ -1,0 +1,49 @@
+@page "/downloaders"
+@inject DownloadersViewmodel Viewmodel
+@using Octans.Core.Downloaders
+
+<div class="downloaders-container">
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Rescan">Rescan</MudButton>
+
+    <MudTable Items="Viewmodel.Downloaders">
+        <HeaderContent>
+            <MudTh>Name</MudTh>
+            <MudTh>Version</MudTh>
+            <MudTh>Creator</MudTh>
+            <MudTh>Homepage</MudTh>
+            <MudTh>Supported Operations</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd>@context.Name</MudTd>
+            <MudTd>@context.Version</MudTd>
+            <MudTd>@context.Creator</MudTd>
+            <MudTd>
+                @if (!string.IsNullOrWhiteSpace(context.Homepage))
+                {
+                    <a href="@context.Homepage" target="_blank">@context.Homepage</a>
+                }
+            </MudTd>
+            <MudTd>
+                @foreach (var op in context.SupportedOperations)
+                {
+                    <MudChip T="string" Size="Size.Small" Style="margin-right:4px;">@op</MudChip>
+                }
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+</div>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        if (RendererInfo.IsInteractive)
+        {
+            await Viewmodel.Load();
+        }
+    }
+
+    private async Task Rescan()
+    {
+        await Viewmodel.Rescan();
+    }
+}

--- a/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
+++ b/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using Octans.Core.Downloaders;
+
+namespace Octans.Client.Components.Downloads;
+
+public class DownloadersViewmodel(DownloaderFactory factory)
+{
+    private readonly DownloaderFactory _factory = factory;
+
+    public List<DownloaderMetadata> Downloaders { get; private set; } = [];
+
+    public async Task Load()
+    {
+        var downloaders = await _factory.GetDownloaders();
+        Downloaders = downloaders.Select(d => d.Metadata).ToList();
+    }
+
+    public async Task Rescan()
+    {
+        var downloaders = await _factory.Rescan();
+        Downloaders = downloaders.Select(d => d.Metadata).ToList();
+    }
+}

--- a/Octans.Client/Components/MainToolbar/MainToolbarViewmodel.cs
+++ b/Octans.Client/Components/MainToolbar/MainToolbarViewmodel.cs
@@ -40,7 +40,14 @@ public class MainToolbarViewmodel(NavigationManager nav)
             new()
             {
                 Name = "downloads",
-                Items = []
+                Items =
+                [
+                    new()
+                    {
+                        Name = "downloaders",
+                        Page = Page.Downloaders
+                    }
+                ]
             },
             new()
             {
@@ -78,6 +85,7 @@ public class MainToolbarViewmodel(NavigationManager nav)
         {
             Page.LocalFiles => "/imports",
             Page.WebUrls => "/imports",
+            Page.Downloaders => "/downloaders",
             Page.Settings => "/settings",
             _ => throw new ArgumentOutOfRangeException(nameof(page), page, null)
         };
@@ -92,6 +100,7 @@ public enum Page
 {
     LocalFiles,
     WebUrls,
+    Downloaders,
     Settings
 }
 

--- a/Octans.Client/ServiceCollectionExtensions.cs
+++ b/Octans.Client/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Octans.Client.Components.MainToolbar;
 using Octans.Client.Components.Pages;
 using Octans.Client.Components.StatusBar;
 using Octans.Client.Components.Progress;
+using Octans.Client.Components.Downloads;
 using Octans.Client.Options;
 using Octans.Core;
 using Octans.Core.Communication;
@@ -174,6 +175,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<StatusBarViewmodel>();
         services.AddScoped<StatusService>();
         services.AddSingleton<ProgressStore>();
+        services.AddScoped<DownloadersViewmodel>();
 
         return services;
     }

--- a/Octans.Core/Downloads/Downloaders/DownloaderFactory.cs
+++ b/Octans.Core/Downloads/Downloaders/DownloaderFactory.cs
@@ -52,6 +52,18 @@ public class DownloaderFactory(
         return _downloaders;
     }
 
+    public async Task<List<Downloader>> Rescan()
+    {
+        foreach (var downloader in _downloaders)
+        {
+            downloader.Dispose();
+        }
+
+        _downloaders.Clear();
+
+        return await GetDownloaders();
+    }
+
     private async Task<Downloader?> Create(List<IFileInfo> sources)
     {
         string[] names = ["metadata", "classifier", "parser", "gug", "api"];


### PR DESCRIPTION
## Summary
- add downloaders page and viewmodel to list available downloaders
- allow re-scanning downloaders directory via new API on factory
- expose downloaders page in main toolbar and register viewmodel in DI

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c3154084708331a8ffefe1a9f8039e