### PR TITLE
Add downloader help dialog and path notice

### DIFF
--- a/Octans.Client/Components/Downloads/Downloaders.razor
+++ b/Octans.Client/Components/Downloads/Downloaders.razor
@@ -1,9 +1,14 @@
 @page "/downloaders"
 @inject DownloadersViewmodel Viewmodel
+@inject IDialogService DialogService
 @using Octans.Core.Downloaders
 
 <div class="downloaders-container">
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Rescan">Rescan</MudButton>
+    <div class="actions">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Rescan">Rescan</MudButton>
+        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Help" OnClick="ShowHelp">Help</MudButton>
+    </div>
+    <MudText Typo="Typo.body2">Looking for downloaders in: @Viewmodel.DownloaderDirectory</MudText>
 
     <MudTable Items="Viewmodel.Downloaders">
         <HeaderContent>
@@ -46,4 +51,19 @@
     {
         await Viewmodel.Rescan();
     }
+
+    private async Task ShowHelp()
+    {
+        const string content = "Downloaders are bundles of Lua files that provide site-specific parsing and downloading functionality.<br/><br/>To add one, create a folder inside the directory shown above and include your Lua files.";
+
+        await DialogService.ShowMessageBox("Downloaders", (MarkupString)content, yesText: "Close");
+    }
 }
+
+<style>
+    .downloaders-container .actions {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+    }
+</style>

--- a/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
+++ b/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
@@ -9,6 +9,8 @@ public class DownloadersViewmodel(DownloaderFactory factory)
 
     public List<DownloaderMetadata> Downloaders { get; private set; } = [];
 
+    public string DownloaderDirectory => _factory.DownloaderDirectory;
+
     public async Task Load()
     {
         var downloaders = await _factory.GetDownloaders();

--- a/Octans.Core/Downloads/Downloaders/DownloaderFactory.cs
+++ b/Octans.Core/Downloads/Downloaders/DownloaderFactory.cs
@@ -14,6 +14,8 @@ public class DownloaderFactory(
 
     private readonly List<Downloader> _downloaders = new();
 
+    public string DownloaderDirectory => fileSystem.Path.Join(_globalSettings.AppRoot, "downloaders");
+
     public async Task<List<Downloader>> GetDownloaders()
     {
         if (_downloaders.Any())
@@ -21,8 +23,7 @@ public class DownloaderFactory(
             return _downloaders;
         }
 
-        var path = fileSystem.Path.Join(_globalSettings.AppRoot, "downloaders");
-        var downloaders = fileSystem.DirectoryInfo.New(path);
+        var downloaders = fileSystem.DirectoryInfo.New(DownloaderDirectory);
 
         if (!downloaders.Exists)
         {


### PR DESCRIPTION
## Summary
- Show downloader directory path in Downloaders page
- Add help dialog explaining downloaders and how to add them
- Expose downloader directory via viewmodel and factory

## Testing
- `dotnet test` *(fails: HttpDownloaderTests.ProcessDownloadAsync_HandlesCancellation_UpdatesStateToCanceled)*

------
https://chatgpt.com/codex/tasks/task_e_68c319a7add88331894e8808b6c6afc1