### PR TITLE
Add import job models and background processor

### DIFF
--- a/Octans.Client/ServiceCollectionExtensions.cs
+++ b/Octans.Client/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddOctansServices(this IServiceCollection services)
     {
         services.AddHostedService<ImportFolderBackgroundService>();
+        services.AddHostedService<ImportProcessorService>();
         services.AddHostedService<SubscriptionBackgroundService>();
         services.AddHostedService<RepositoryChangeBackgroundService>();
 

--- a/Octans.Core/Importing/ImportProcessorService.cs
+++ b/Octans.Core/Importing/ImportProcessorService.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Octans.Core.Models;
+using Octans.Core.Progress;
+using Octans.Core.Importing.Jobs;
+
+namespace Octans.Core.Importing;
+
+public class ImportProcessorService(
+    IServiceProvider serviceProvider,
+    ILogger<ImportProcessorService> logger,
+    IBackgroundProgressReporter progress) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Import processor service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = serviceProvider.CreateScope();
+                var context = scope.ServiceProvider.GetRequiredService<ServerDbContext>();
+                var importer = scope.ServiceProvider.GetRequiredService<IImporter>();
+
+                var job = await context.ImportJobs
+                    .Include(j => j.Items)
+                    .FirstOrDefaultAsync(j => j.Status == ImportJobStatus.Queued, stoppingToken);
+
+                if (job != null)
+                {
+                    logger.LogInformation("Processing import job {JobId}", job.Id);
+                    job.Status = ImportJobStatus.InProgress;
+                    await context.SaveChangesAsync(stoppingToken);
+
+                    var request = JsonSerializer.Deserialize<ImportRequest>(job.SerializedRequest);
+                    if (request is null)
+                    {
+                        logger.LogError("Failed to deserialize import request for job {JobId}", job.Id);
+                        job.Status = ImportJobStatus.Failed;
+                        await context.SaveChangesAsync(stoppingToken);
+                    }
+                    else
+                    {
+                        var handle = await progress.Start("Import", request.Items.Count);
+                        var result = await importer.ProcessImport(request, handle.Id, stoppingToken);
+
+                        for (var i = 0; i < job.Items.Count && i < result.Results.Count; i++)
+                        {
+                            var item = job.Items[i];
+                            var itemResult = result.Results[i];
+                            item.Status = itemResult.Ok ? ImportItemStatus.Completed : ImportItemStatus.Failed;
+                            item.Error = itemResult.Ok ? null : itemResult.Message;
+                        }
+
+                        job.Status = ImportJobStatus.Completed;
+                        await progress.Complete(handle.Id);
+                        await context.SaveChangesAsync(stoppingToken);
+                    }
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error while processing import job");
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            }
+        }
+    }
+}

--- a/Octans.Data/Migrations/20250913072413_AddImportJobTables.Designer.cs
+++ b/Octans.Data/Migrations/20250913072413_AddImportJobTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Octans.Core.Models;
 
@@ -10,9 +11,11 @@ using Octans.Core.Models;
 namespace Octans.Server.Migrations
 {
     [DbContext(typeof(ServerDbContext))]
-    partial class ServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250913072413_AddImportJobTables")]
+    partial class AddImportJobTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/Octans.Data/Migrations/20250913072413_AddImportJobTables.cs
+++ b/Octans.Data/Migrations/20250913072413_AddImportJobTables.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Octans.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImportJobTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ImportJobs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false),
+                    SerializedRequest = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportJobs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ImportItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ImportJobId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Source = table.Column<string>(type: "TEXT", nullable: false),
+                    Status = table.Column<int>(type: "INTEGER", nullable: false),
+                    Error = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImportItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ImportItems_ImportJobs_ImportJobId",
+                        column: x => x.ImportJobId,
+                        principalTable: "ImportJobs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImportItems_ImportJobId",
+                table: "ImportItems",
+                column: "ImportJobId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ImportItems");
+
+            migrationBuilder.DropTable(
+                name: "ImportJobs");
+        }
+    }
+}

--- a/Octans.Data/Models/Importing/ImportItem.cs
+++ b/Octans.Data/Models/Importing/ImportItem.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octans.Core.Importing.Jobs;
+
+public class ImportItem
+{
+    [Key]
+    public Guid Id { get; set; }
+    public Guid ImportJobId { get; set; }
+    public required string Source { get; set; }
+    public ImportItemStatus Status { get; set; }
+    public string? Error { get; set; }
+    public ImportJob? ImportJob { get; set; }
+}
+
+public enum ImportItemStatus
+{
+    Pending,
+    Processing,
+    Completed,
+    Failed
+}

--- a/Octans.Data/Models/Importing/ImportJob.cs
+++ b/Octans.Data/Models/Importing/ImportJob.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Octans.Core.Importing.Jobs;
+
+public class ImportJob
+{
+    [Key]
+    public Guid Id { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public ImportJobStatus Status { get; set; }
+    public required string SerializedRequest { get; set; }
+    public List<ImportItem> Items { get; set; } = [];
+}
+
+public enum ImportJobStatus
+{
+    Queued,
+    InProgress,
+    Paused,
+    Completed,
+    Failed
+}

--- a/Octans.Data/Models/ServerDbContext.cs
+++ b/Octans.Data/Models/ServerDbContext.cs
@@ -3,6 +3,7 @@ using Octans.Core.Downloaders;
 using Octans.Core.Models.Tagging;
 using Octans.Core.Repositories;
 using Octans.Core.Models.Ratings;
+using Octans.Core.Importing.Jobs;
 
 namespace Octans.Core.Models;
 
@@ -23,6 +24,8 @@ public class ServerDbContext(DbContextOptions<ServerDbContext> context) : DbCont
     public virtual DbSet<Subscription> Subscriptions { get; set; }
     public virtual DbSet<RatingSystem> RatingSystems { get; set; }
     public virtual DbSet<HashRating> HashRatings { get; set; }
+    public virtual DbSet<ImportJob> ImportJobs { get; set; }
+    public virtual DbSet<ImportItem> ImportItems { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Octans.Tests/Importing/ImporterTests.cs
+++ b/Octans.Tests/Importing/ImporterTests.cs
@@ -10,6 +10,7 @@ using Octans.Client;
 using Octans.Core;
 using Octans.Core.Models;
 using Octans.Server;
+using Octans.Core.Progress;
 using Xunit.Abstractions;
 
 namespace Octans.Tests;
@@ -32,6 +33,7 @@ public sealed class ImporterTests : IAsyncLifetime, IClassFixture<DatabaseFixtur
 
         services.AddLogging(s => s.AddProvider(new XUnitLoggerProvider(testOutputHelper)));
         services.AddBusinessServices();
+        services.AddSingleton<IBackgroundProgressReporter, NoOpProgressReporter>();
 
         services.AddDbContext<ServerDbContext>(options => { options.UseSqlite(databaseFixture.Connection); },
             optionsLifetime: ServiceLifetime.Singleton);
@@ -49,6 +51,20 @@ public sealed class ImporterTests : IAsyncLifetime, IClassFixture<DatabaseFixtur
         _provider = services.BuildServiceProvider();
 
         _sut = _provider.GetRequiredService<IImporter>();
+    }
+
+    private sealed class NoOpProgressReporter : IBackgroundProgressReporter
+    {
+        public Task<ProgressHandle> Start(string operation, int totalItems) =>
+            Task.FromResult(new ProgressHandle(Guid.NewGuid(), operation, totalItems));
+
+        public Task Report(Guid id, int processed) => Task.CompletedTask;
+
+        public Task Complete(Guid id) => Task.CompletedTask;
+
+        public Task ReportMessage(string message) => Task.CompletedTask;
+
+        public Task ReportError(string message) => Task.CompletedTask;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add ImportJob and ImportItem EF models with job/item status tracking
- support progress reporting in Importer and queue processing service
- register ImportProcessorService to handle queued import jobs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c519b16c5483319f5c8daeb0125a55