### PR TITLE
Refactor downloader to resolve URLs and queue file downloads

### DIFF
--- a/Octans.Client/ServiceCollectionExtensions.cs
+++ b/Octans.Client/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Octans.Client.Options;
 using Octans.Core;
 using Octans.Core.Communication;
 using Octans.Core.Downloaders;
+using Octans.Core.Downloads;
 using Octans.Core.Importing;
 using Octans.Core.Infrastructure;
 using Octans.Core.Models;
@@ -91,6 +92,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<FileFinder>();
         services.AddScoped<FileDeleter>();
         services.AddScoped<TagUpdater>();
+
+        services.AddSingleton(TimeProvider.System);
+        services.AddBandwidthLimiter();
+        services.AddDownloadManager();
+        services.AddMediator();
 
         // Queries
         services.AddScoped<IQueryService, QueryService>();

--- a/Octans.Core/Importing/Importer.cs
+++ b/Octans.Core/Importing/Importer.cs
@@ -76,11 +76,15 @@ public class Importer(
             throw new ArgumentException("Import item had both a URL and a filepath specified.", nameof(item));
         }
 
+        if (request.ImportType is ImportType.Post)
+        {
+            return await post.Import(item);
+        }
+
         var task = request.ImportType switch
         {
             ImportType.File => file.GetRawBytes(item),
             ImportType.RawUrl => simple.GetRawBytes(item),
-            ImportType.Post => post.GetRawBytes(item),
             ImportType.Gallery => throw new NotImplementedException(),
             ImportType.Watchable => throw new NotImplementedException(),
             _ => throw new ArgumentOutOfRangeException()

--- a/Octans.Core/Importing/RawByteProviders/PostImporter.cs
+++ b/Octans.Core/Importing/RawByteProviders/PostImporter.cs
@@ -1,12 +1,33 @@
+using System.IO;
 using Octans.Core.Downloaders;
-using Octans.Core.Importing.RawByteProviders;
+using Octans.Core.Downloads;
 
 namespace Octans.Core.Importing;
 
-public class PostImporter(DownloaderService downloaderService) : IRawByteProvider
+public class PostImporter(
+    DownloaderService downloaderService,
+    IDownloadService downloadService)
 {
-    public async Task<byte[]> GetRawBytes(ImportItem item)
+    public async Task<ImportItemResult> Import(ImportItem item)
     {
-        return await downloaderService.Download(item.Url ?? throw new ArgumentException("Item had a null URL.", nameof(item)));
+        var uri = item.Url ?? throw new ArgumentException("Item had a null URL.", nameof(item));
+
+        var urls = await downloaderService.ResolveAsync(uri);
+
+        foreach (var direct in urls)
+        {
+            var destination = Path.Combine(Path.GetTempPath(), Path.GetFileName(direct.LocalPath));
+
+            await downloadService.QueueDownloadAsync(new()
+            {
+                Url = direct,
+                DestinationPath = destination
+            });
+        }
+
+        return urls.Count > 0
+            ? new ImportItemResult { Ok = true }
+            : new ImportItemResult { Ok = false, Message = "No downloadable URLs found." };
     }
 }
+


### PR DESCRIPTION
## Summary
- Replace DownloaderService.Download with ResolveAsync to return direct file URLs
- Queue post downloads via IDownloadService instead of fetching bytes directly
- Register download pipeline services and handle post imports accordingly

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c51f86e6448331855c2a0ef550a7fe