### PR TITLE
Add SBOM generation to CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,12 @@ jobs:
         path: .
         format: spdx-json
         output-file: sbom.spdx.json
-        artifact-name: sbom
+
+    - name: Upload SBOM artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: sbom
+        path: sbom.spdx.json
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,14 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
 
+    - name: Generate SBOM
+      uses: anchore/sbom-action@v0
+      with:
+        path: .
+        format: spdx-json
+        output-file: sbom.spdx.json
+        artifact-name: sbom
+
     - name: Upload coverage report
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Run `dotnet test` on the `Octans.Tests` project to run automated tests.
 - SixLabors.ImageSharp for image processing
 - Lua for extensible downloaders
 
+## SBOM
+
+The continuous integration workflow generates a Software Bill of Materials (SBOM) using Anchore's SBOM action. An SPDX document (`sbom.spdx.json`) is produced for each build and uploaded as a workflow artifact to help track project dependencies.
+
 ## License
 
 MIT license.


### PR DESCRIPTION
## Summary
- generate SPDX SBOM using Anchore sbom-action during CI
- document SBOM artifact in README

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68c52a4b5a588331826d9dd9d1b1b7b5