### PR TITLE
Fix Lua downloader lifecycle and gallery resolution

### DIFF
--- a/Octans.Core/Downloads/Downloaders/DownloaderFactory.cs
+++ b/Octans.Core/Downloads/Downloaders/DownloaderFactory.cs
@@ -96,7 +96,7 @@ public class DownloaderFactory(
                 continue;
             }
 
-            using var lua = new Lua();
+            var lua = new Lua();
 
             try
             {
@@ -105,6 +105,7 @@ public class DownloaderFactory(
             catch (Exception e)
             {
                 logger.LogError(e, "Error loading raw Lua string");
+                lua.Dispose();
                 return null;
             }
 

--- a/Octans.Core/Downloads/Downloaders/DownloaderService.cs
+++ b/Octans.Core/Downloads/Downloaders/DownloaderService.cs
@@ -32,7 +32,8 @@ public class DownloaderService(
 
         if (classification is DownloaderUrlClassification.Gallery)
         {
-            raw = matching.GenerateGalleryHtml(uri.AbsoluteUri, 0);
+            var galleryUrl = matching.GenerateGalleryUrl(uri.AbsoluteUri, 0);
+            raw = await client.GetStringAsync(new Uri(galleryUrl));
         }
 
         var urls = matching


### PR DESCRIPTION
## Summary
- avoid disposing Lua contexts during downloader factory creation
- keep downloader Lua contexts alive and dispose them properly
- fetch gallery HTML from generated URLs

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c52a8c92a08331a97a4ba75756c4ea