### PR TITLE
Fix MediatorGenerator warnings by relocating source generator

### DIFF
--- a/Octans.Client/Octans.Client.csproj
+++ b/Octans.Client/Octans.Client.csproj
@@ -23,6 +23,10 @@
         <PackageReference Include="Swashbuckle.AspNetCore"/>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
         <PackageReference Include="Toolbelt.Blazor.SplitContainer" />
+        <PackageReference Include="Mediator.SourceGenerator">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Octans.Core/Octans.Core.csproj
+++ b/Octans.Core/Octans.Core.csproj
@@ -6,10 +6,6 @@
 
     <ItemGroup>
         <PackageReference Include="Mediator.Abstractions" />
-        <PackageReference Include="Mediator.SourceGenerator">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Http"/>


### PR DESCRIPTION
## Summary
- Remove Mediator.SourceGenerator from core library
- Add Mediator.SourceGenerator to client project so handlers are registered

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c53d5d727c8331aa1de15f84ddd235