### PR TITLE
Integrate configuration page into settings

### DIFF
--- a/Octans.Client/Components/Config/Config.razor
+++ b/Octans.Client/Components/Config/Config.razor
@@ -1,14 +1,10 @@
-@page "/config"
 @using Microsoft.Extensions.Localization
 @using Octans.Client.Config
 @inject ConfigViewModel ViewModel
 @inject IJSRuntime JsRuntime
 @inject ThemeService ThemeService
 @inject IStringLocalizer<Config> L
-@rendermode InteractiveServer
 @implements IDisposable
-
-<PageTitle>Octans - Configuration</PageTitle>
 
 <div class="config-container">
     <div class="header">

--- a/Octans.Client/Components/Home.razor
+++ b/Octans.Client/Components/Home.razor
@@ -49,11 +49,6 @@
             <div class="nav-card-title">Imports</div>
             <div class="nav-card-description">Add new content to your collection</div>
         </a>
-        <a href="/config" class="nav-card">
-            <div class="nav-card-icon">⚙️</div>
-            <div class="nav-card-title">Configuration</div>
-            <div class="nav-card-description">Configure application settings</div>
-        </a>
     </div>
 </div>
 

--- a/Octans.Client/Components/Settings/Settings.razor
+++ b/Octans.Client/Components/Settings/Settings.razor
@@ -1,5 +1,6 @@
 @page "/settings"
 @rendermode InteractiveServer
+@using Octans.Client.Components.Config
 
 <CascadingValue Value="_context">
     <div class="settings-layout">
@@ -8,6 +9,10 @@
             <SettingsSidebar Pages="_context.Pages" ActivePage="_activePage" OnSelectPage="SelectPage" />
             <div class="settings-content">
                 <CascadingValue Value="_activePage">
+                    <SettingsPage Title="Configuration" Icon="⚙️">
+                        <Config />
+                    </SettingsPage>
+
                     <SettingsPage Title="Import">
                         <SettingItem Name="Import Source" Tags=@(new[] { "import" })>
                             <Control>


### PR DESCRIPTION
## Summary
- remove configuration navigation card from home page
- embed configuration component in settings as new section
- drop standalone /config route

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c541598fe48331b170444413eb07c4