### PR TITLE
feat: persist user settings

### DIFF
--- a/Octans.Client/Octans.Client.csproj
+++ b/Octans.Client/Octans.Client.csproj
@@ -14,6 +14,9 @@
         <Content Update="appsettings.Development.json">
             <DependentUpon>appsettings.json</DependentUpon>
         </Content>
+        <Content Update="usersettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
     <ItemGroup>

--- a/Octans.Client/Program.cs
+++ b/Octans.Client/Program.cs
@@ -12,6 +12,8 @@ using Octans.Core.Downloads;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Configuration.AddJsonFile("usersettings.json", optional: true, reloadOnChange: true);
+
 builder.Services
     .AddRazorComponents()
     .AddInteractiveServerComponents();

--- a/Octans.Client/ServiceCollectionExtensions.cs
+++ b/Octans.Client/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using Octans.Client.Components.Progress;
 using Octans.Client.Downloads;
 using Octans.Client.Components.Downloads;
 using Octans.Client.Options;
+using Octans.Client.Settings;
 using Octans.Core;
 using Octans.Core.Communication;
 using Octans.Core.Downloaders;
@@ -166,6 +167,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IClipboard, Clipboard>();
         services.AddScoped<ThemeService>();
         services.AddScoped<ShellService>();
+        services.AddScoped<ISettingsService, SettingsService>();
 
         services.AddMediator();
 
@@ -207,6 +209,7 @@ public static class ServiceCollectionExtensions
     public static void SetupConfiguration(this WebApplicationBuilder builder)
     {
         builder.Services.Configure<GlobalSettings>(builder.Configuration.GetSection(nameof(GlobalSettings)));
+        builder.Services.Configure<UserSettings>(builder.Configuration.GetSection(nameof(UserSettings)));
 
         builder
             .Services

--- a/Octans.Client/Settings/SettingsModel.cs
+++ b/Octans.Client/Settings/SettingsModel.cs
@@ -1,4 +1,4 @@
-namespace Octans.Client.Components.Settings;
+namespace Octans.Client.Settings;
 
 public class SettingsModel
 {

--- a/Octans.Client/Settings/SettingsService.cs
+++ b/Octans.Client/Settings/SettingsService.cs
@@ -1,0 +1,75 @@
+using System.IO.Abstractions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Octans.Client.Settings;
+
+public interface ISettingsService
+{
+    Task<SettingsModel> LoadAsync();
+    Task SaveAsync(SettingsModel model);
+}
+
+public class SettingsService(
+    IConfiguration configuration,
+    IFileSystem fileSystem,
+    IHostEnvironment environment,
+    ILogger<SettingsService> logger) : ISettingsService
+{
+    private readonly string _settingsPath = fileSystem.Path.Combine(environment.ContentRootPath, "usersettings.json");
+
+    public Task<SettingsModel> LoadAsync()
+    {
+        var model = new SettingsModel
+        {
+            Theme = configuration.GetValue<string>("UserSettings:Theme") ?? "light",
+            AppRoot = configuration.GetValue<string>("GlobalSettings:AppRoot") ?? string.Empty,
+            LogLevel = configuration.GetValue<string>("Logging:LogLevel:Default") ?? "Information",
+            AspNetCoreLogLevel = configuration.GetValue<string>("Logging:LogLevel:Microsoft.AspNetCore") ?? "Warning",
+            ImportSource = configuration.GetValue<string>("UserSettings:ImportSource") ?? string.Empty,
+            TagColor = configuration.GetValue<string>("UserSettings:TagColor") ?? "#000000"
+        };
+
+        return Task.FromResult(model);
+    }
+
+    public async Task SaveAsync(SettingsModel model)
+    {
+        var contents = new
+        {
+            UserSettings = new
+            {
+                model.Theme,
+                model.ImportSource,
+                model.TagColor
+            },
+            GlobalSettings = new
+            {
+                model.AppRoot
+            },
+            Logging = new
+            {
+                LogLevel = new Dictionary<string, string>
+                {
+                    ["Default"] = model.LogLevel,
+                    ["Microsoft.AspNetCore"] = model.AspNetCoreLogLevel
+                }
+            }
+        };
+
+        try
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+            var json = JsonSerializer.Serialize(contents, options);
+            await fileSystem.File.WriteAllTextAsync(_settingsPath, json);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to write settings file: {Path}", _settingsPath);
+            throw;
+        }
+    }
+}

--- a/Octans.Client/Settings/UserSettings.cs
+++ b/Octans.Client/Settings/UserSettings.cs
@@ -1,0 +1,8 @@
+namespace Octans.Client.Settings;
+
+public class UserSettings
+{
+    public string Theme { get; set; } = "light";
+    public string ImportSource { get; set; } = string.Empty;
+    public string TagColor { get; set; } = "#000000";
+}

--- a/Octans.Client/usersettings.json
+++ b/Octans.Client/usersettings.json
@@ -1,0 +1,7 @@
+{
+  "UserSettings": {
+    "Theme": "light",
+    "ImportSource": "",
+    "TagColor": "#000000"
+  }
+}


### PR DESCRIPTION
## Summary
- add user settings service to load and save configuration to usersettings.json
- wire up service and options in DI
- update settings viewmodel to persist and rehydrate settings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c5616c049c8331971b871a4ad3fc6c