### PR TITLE
Add Dockerfile and document container setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+COPY ["Octans.sln", "."]
+COPY ["Directory.Build.props", "."]
+COPY ["Directory.Packages.props", "."]
+COPY ["Octans.Client/Octans.Client.csproj", "Octans.Client/"]
+COPY ["Octans.Core/Octans.Core.csproj", "Octans.Core/"]
+COPY ["Octans.Data/Octans.Data.csproj", "Octans.Data/"]
+COPY ["Octans.Tests/Octans.Tests.csproj", "Octans.Tests/"]
+
+RUN dotnet restore "Octans.Client/Octans.Client.csproj"
+
+COPY . .
+WORKDIR /src/Octans.Client
+RUN dotnet publish "Octans.Client.csproj" -c Release -o /app/publish --no-restore
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Octans.Client.dll"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Run `dotnet test` on the `Octans.Tests` project to run automated tests.
    dotnet run --project HydrusReplacement.Client
    ```
 
+A Dockerfile is provided for easy containerized setup.
+
 ## Tech used
 
 - Blazor for the UI


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that publishes and runs the Octans client
- update the README to mention the new Dockerfile for containerized setup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93a5b20748331872d14cdad060b53