### PR TITLE
Add per-domain download request headers and request fingerprinting

### DIFF
--- a/Octans.Core/Downloads/DatabaseDownloadQueue.cs
+++ b/Octans.Core/Downloads/DatabaseDownloadQueue.cs
@@ -75,7 +75,8 @@ public class DatabaseDownloadQueue(
             Priority = status.Priority,
             Domain = status.Domain,
             SourceType = status.SourceType,
-            SourceId = status.SourceId
+            SourceId = status.SourceId,
+            RequestFingerprint = status.RequestFingerprint
         });
 
         await db.SaveChangesAsync(cancellationToken);

--- a/Octans.Core/Downloads/DownloadLifecycleService.cs
+++ b/Octans.Core/Downloads/DownloadLifecycleService.cs
@@ -28,6 +28,7 @@ public sealed class DownloadLifecycleService(
     IDownloadStateService stateService,
     IActiveDownloadRegistry activeDownloads,
     IDownloadCompletionNotifier completionNotifier,
+    IDownloadRequestHeaderProvider requestHeaderProvider,
     TimeProvider timeProvider,
     ILogger<DownloadLifecycleService> logger) : IDownloadLifecycleService
 {
@@ -72,7 +73,8 @@ public sealed class DownloadLifecycleService(
             LastUpdated = now,
             Domain = domain,
             SourceType = request.SourceType,
-            SourceId = request.SourceId
+            SourceId = request.SourceId,
+            RequestFingerprint = requestHeaderProvider.GetRequestFingerprint(request.Url)
         };
 
         await stateService.QueueDownloadAsync(status);

--- a/Octans.Core/Downloads/DownloadRequestHeaderProvider.cs
+++ b/Octans.Core/Downloads/DownloadRequestHeaderProvider.cs
@@ -1,0 +1,165 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Octans.Core.Downloads.Models;
+
+namespace Octans.Core.Downloads;
+
+public interface IDownloadRequestHeaderProvider
+{
+    DownloadRequestHeaders GetHeaders(Uri uri);
+    string GetRequestFingerprint(Uri uri);
+    void ApplyHeaders(HttpRequestMessage request);
+}
+
+public sealed class DownloadRequestHeaderProvider(IOptions<DownloadManagerOptions> options) : IDownloadRequestHeaderProvider
+{
+    private static readonly HashSet<string> SensitiveHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Cookie",
+        "Proxy-Authorization",
+        "Set-Cookie"
+    };
+
+    public DownloadRequestHeaders GetHeaders(Uri uri)
+    {
+        var headerOptions = options.Value.RequestHeaders;
+        var domain = GetMatchingDomainOptions(uri.Host, headerOptions.Domains);
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        AddHeader(headers, "User-Agent", domain?.UserAgent ?? headerOptions.DefaultUserAgent);
+        AddHeader(headers, "Authorization", domain?.Authorization);
+        AddHeader(headers, "Cookie", domain?.Cookie);
+
+        foreach (var (name, value) in headerOptions.Headers)
+        {
+            AddHeader(headers, name, value);
+        }
+
+        if (domain is not null)
+        {
+            foreach (var (name, value) in domain.Headers)
+            {
+                AddHeader(headers, name, value);
+            }
+        }
+
+        var missingRequiredHeaders = GetMissingRequiredHeaders(headers, headerOptions.RequiredHeaders, domain?.RequiredHeaders);
+        return new(headers, missingRequiredHeaders);
+    }
+
+    public string GetRequestFingerprint(Uri uri)
+    {
+        var requestHeaders = GetHeaders(uri);
+        var builder = new StringBuilder();
+        builder.Append("GET\n");
+        builder.Append(uri.AbsoluteUri).Append('\n');
+
+        foreach (var (name, value) in requestHeaders.Headers.OrderBy(h => h.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            builder.Append(name.ToLowerInvariant()).Append(':').Append(value).Append('\n');
+        }
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString())));
+    }
+
+    public void ApplyHeaders(HttpRequestMessage request)
+    {
+        if (request.RequestUri is null)
+        {
+            return;
+        }
+
+        var requestHeaders = GetHeaders(request.RequestUri);
+        if (requestHeaders.MissingRequiredHeaders.Count > 0)
+        {
+            throw MissingDownloadCredentialsException.ForMissingHeaders(request.RequestUri.Host, requestHeaders.MissingRequiredHeaders);
+        }
+
+        foreach (var (name, value) in requestHeaders.Headers)
+        {
+            request.Headers.Remove(name);
+            request.Headers.TryAddWithoutValidation(name, value);
+        }
+    }
+
+    public static string RedactHeaderValue(string name, string value)
+    {
+        return SensitiveHeaderNames.Contains(name) ? "[redacted]" : value;
+    }
+
+    private static DownloadDomainRequestHeaderOptions? GetMatchingDomainOptions(
+        string host,
+        IReadOnlyDictionary<string, DownloadDomainRequestHeaderOptions> domains)
+    {
+        DownloadDomainRequestHeaderOptions? bestMatch = null;
+        var bestMatchLength = -1;
+
+        foreach (var (pattern, domainOptions) in domains)
+        {
+            if (!HostMatchesPattern(host, pattern))
+            {
+                continue;
+            }
+
+            var matchLength = pattern.TrimStart('*', '.').Length;
+            if (matchLength <= bestMatchLength)
+            {
+                continue;
+            }
+
+            bestMatch = domainOptions;
+            bestMatchLength = matchLength;
+        }
+
+        return bestMatch;
+    }
+
+    private static bool HostMatchesPattern(string host, string pattern)
+    {
+        if (host.Equals(pattern, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var normalizedPattern = pattern.StartsWith("*.", StringComparison.Ordinal)
+            ? pattern[2..]
+            : pattern.TrimStart('.');
+
+        if (normalizedPattern.Length == pattern.Length)
+        {
+            return false;
+        }
+
+        return host.EndsWith($".{normalizedPattern}", StringComparison.OrdinalIgnoreCase)
+               || host.Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AddHeader(Dictionary<string, string> headers, string name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        headers[name] = value;
+    }
+
+    private static List<string> GetMissingRequiredHeaders(
+        Dictionary<string, string> headers,
+        IEnumerable<string> globalRequiredHeaders,
+        IEnumerable<string>? domainRequiredHeaders)
+    {
+        return globalRequiredHeaders
+            .Concat(domainRequiredHeaders ?? [])
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(name => !headers.TryGetValue(name, out var value) || string.IsNullOrWhiteSpace(value))
+            .ToList();
+    }
+}
+
+public sealed record DownloadRequestHeaders(
+    IReadOnlyDictionary<string, string> Headers,
+    IReadOnlyList<string> MissingRequiredHeaders);

--- a/Octans.Core/Downloads/DownloadServiceExtensions.cs
+++ b/Octans.Core/Downloads/DownloadServiceExtensions.cs
@@ -28,6 +28,7 @@ public static class DownloadServiceExtensions
         services.TryAddSingleton<IDownloadBandwidthGate, NoOpDownloadBandwidthGate>();
         services.TryAddSingleton<IDownloadDiskSpaceGuard, DownloadDiskSpaceGuard>();
         services.TryAddSingleton<IDownloadHostCircuitRegistry, DownloadHostCircuitRegistry>();
+        services.TryAddSingleton<IDownloadRequestHeaderProvider, DownloadRequestHeaderProvider>();
         services.TryAddSingleton<DownloadStagingPaths>();
         services.TryAddSingleton<IDownloadLifecycleService, DownloadLifecycleService>();
         services.TryAddSingleton<HttpDownloader>();
@@ -35,10 +36,7 @@ public static class DownloadServiceExtensions
         services.TryAddSingleton<IDownloadQueue, DatabaseDownloadQueue>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DownloadBackgroundService>());
 
-        services.AddHttpClient("DownloadClient", client =>
-            {
-                client.DefaultRequestHeaders.UserAgent.ParseAdd("Octans/1.0");
-            })
+        services.AddHttpClient("DownloadClient")
             .AddStandardResilienceHandler()
             .Configure((resilienceOptions, provider) =>
                 ConfigureDownloadResilience(resilienceOptions, provider))

--- a/Octans.Core/Downloads/DownloadStatusTracker.cs
+++ b/Octans.Core/Downloads/DownloadStatusTracker.cs
@@ -469,7 +469,8 @@ public class DownloadStatusTracker(
         ValidationMessage = status.ValidationMessage,
         Domain = status.Domain,
         SourceType = status.SourceType,
-        SourceId = status.SourceId
+        SourceId = status.SourceId,
+        RequestFingerprint = status.RequestFingerprint
     };
 
     private static void ApplyPersistedState(DownloadStatus target, DownloadStatus source)
@@ -489,6 +490,7 @@ public class DownloadStatusTracker(
         target.ResponseETag = source.ResponseETag;
         target.ResponseLastModified = source.ResponseLastModified;
         target.ValidationMessage = source.ValidationMessage;
+        target.RequestFingerprint = source.RequestFingerprint;
     }
 
     private static void ApplyTerminalResult(DownloadStatus status, DownloadTerminalUpdate terminalUpdate)
@@ -533,6 +535,7 @@ public class DownloadStatusTracker(
         queuedDownload.Domain = status.Domain;
         queuedDownload.SourceType = status.SourceType;
         queuedDownload.SourceId = status.SourceId;
+        queuedDownload.RequestFingerprint = status.RequestFingerprint;
     }
 
     private static QueuedDownload BuildQueuedDownload(DownloadStatus status, DateTimeOffset queuedAt) => new()
@@ -546,6 +549,7 @@ public class DownloadStatusTracker(
         Priority = status.Priority,
         Domain = status.Domain,
         SourceType = status.SourceType,
-        SourceId = status.SourceId
+        SourceId = status.SourceId,
+        RequestFingerprint = status.RequestFingerprint
     };
 }

--- a/Octans.Core/Downloads/Downloaders/DownloaderService.cs
+++ b/Octans.Core/Downloads/Downloaders/DownloaderService.cs
@@ -1,8 +1,11 @@
+using Octans.Core.Downloads;
+
 namespace Octans.Core.Downloads.Downloaders;
 
 public class DownloaderService(
     IHttpClientFactory clientFactory,
-    DownloaderFactory downloaderFactory)
+    DownloaderFactory downloaderFactory,
+    IDownloadRequestHeaderProvider requestHeaderProvider)
 {
     public async Task<IReadOnlyList<Uri>> ResolveAsync(Uri uri)
     {
@@ -16,10 +19,10 @@ public class DownloaderService(
         }
 
 #pragma warning disable CA2000
-        var client = clientFactory.CreateClient();
+        var client = clientFactory.CreateClient("DownloadClient");
 #pragma warning restore CA2000
 
-        var raw = await client.GetStringAsync(uri);
+        var raw = await GetStringAsync(client, uri);
 
         var classification = matching.ClassifyUrl(uri);
 
@@ -31,7 +34,7 @@ public class DownloaderService(
         if (classification is DownloaderUrlClassification.Gallery)
         {
             var galleryUrl = matching.GenerateGalleryUrl(uri.AbsoluteUri, 0);
-            raw = await client.GetStringAsync(new Uri(galleryUrl));
+            raw = await GetStringAsync(client, new Uri(galleryUrl));
         }
 
         var urls = matching
@@ -40,5 +43,15 @@ public class DownloaderService(
             .ToList();
 
         return urls;
+    }
+
+    private async Task<string> GetStringAsync(HttpClient client, Uri uri)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        requestHeaderProvider.ApplyHeaders(request);
+
+        using var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
     }
 }

--- a/Octans.Core/Downloads/HttpDownloader.cs
+++ b/Octans.Core/Downloads/HttpDownloader.cs
@@ -19,6 +19,7 @@ public class HttpDownloader(
     IActiveDownloadRegistry activeDownloads,
     IDownloadHostCircuitRegistry hostCircuitRegistry,
     IHttpClientFactory httpClientFactory,
+    IDownloadRequestHeaderProvider requestHeaderProvider,
     IFileSystem fileSystem,
     DownloadStagingPaths stagingPaths,
     TimeProvider timeProvider,
@@ -65,6 +66,16 @@ public class HttpDownloader(
                 downloadId,
                 message,
                 DownloadFailureCategory.Network);
+        }
+        catch (MissingDownloadCredentialsException ex)
+        {
+            logger.LogWarning(ex, "Download cannot start because required credentials are missing: {Url}", download.Url);
+            await lifecycle.MarkFailedAsync(
+                downloadId,
+                ex.Message,
+                DownloadFailureCategory.Authentication,
+                DownloadTerminalOutcome.ValidationFailed,
+                validationMessage: ex.Message);
         }
         catch (DownloadContentTypeException ex)
         {
@@ -133,8 +144,11 @@ public class HttpDownloader(
 
         try
         {
-            using var response = await httpClient.GetAsync(
-                new Uri(download.Url),
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(download.Url));
+            requestHeaderProvider.ApplyHeaders(request);
+
+            using var response = await httpClient.SendAsync(
+                request,
                 HttpCompletionOption.ResponseHeadersRead,
                 combinedToken);
 

--- a/Octans.Core/Downloads/MissingDownloadCredentialsException.cs
+++ b/Octans.Core/Downloads/MissingDownloadCredentialsException.cs
@@ -1,0 +1,22 @@
+namespace Octans.Core.Downloads;
+
+public sealed class MissingDownloadCredentialsException : InvalidOperationException
+{
+    public MissingDownloadCredentialsException()
+    {
+    }
+
+    public MissingDownloadCredentialsException(string message) : base(message)
+    {
+    }
+
+    public MissingDownloadCredentialsException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public static MissingDownloadCredentialsException ForMissingHeaders(string domain, IReadOnlyList<string> headerNames)
+    {
+        var headers = string.Join(", ", headerNames.OrderBy(name => name, StringComparer.OrdinalIgnoreCase));
+        return new($"Download credentials are missing for {domain}. Required request headers are not configured: {headers}.");
+    }
+}

--- a/Octans.Core/Downloads/Models/DownloadManagerOptions.cs
+++ b/Octans.Core/Downloads/Models/DownloadManagerOptions.cs
@@ -8,6 +8,24 @@ public class DownloadManagerOptions
     public DownloadSizeLimitOptions SizeLimits { get; set; } = new();
     public DownloadContentTypeValidationOptions ContentTypeValidation { get; set; } = new();
     public DownloadHostCircuitBreakerOptions HostCircuitBreaker { get; set; } = new();
+    public DownloadRequestHeaderOptions RequestHeaders { get; set; } = new();
+}
+
+public class DownloadRequestHeaderOptions
+{
+    public string DefaultUserAgent { get; set; } = "Octans/1.0";
+    public Dictionary<string, string> Headers { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public ICollection<string> RequiredHeaders { get; } = [];
+    public Dictionary<string, DownloadDomainRequestHeaderOptions> Domains { get; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+public class DownloadDomainRequestHeaderOptions
+{
+    public string? UserAgent { get; set; }
+    public string? Authorization { get; set; }
+    public string? Cookie { get; set; }
+    public Dictionary<string, string> Headers { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public ICollection<string> RequiredHeaders { get; } = [];
 }
 
 public class DownloadHostCircuitBreakerOptions

--- a/Octans.Data/Migrations/20260515142038_AddDownloadRequestFingerprint.Designer.cs
+++ b/Octans.Data/Migrations/20260515142038_AddDownloadRequestFingerprint.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Octans.Data.Models;
 
@@ -10,9 +11,11 @@ using Octans.Data.Models;
 namespace Octans.Server.Migrations
 {
     [DbContext(typeof(ServerDbContext))]
-    partial class ServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515142038_AddDownloadRequestFingerprint")]
+    partial class AddDownloadRequestFingerprint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/Octans.Data/Migrations/20260515142038_AddDownloadRequestFingerprint.cs
+++ b/Octans.Data/Migrations/20260515142038_AddDownloadRequestFingerprint.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Octans.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDownloadRequestFingerprint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RequestFingerprint",
+                table: "QueuedDownloads",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequestFingerprint",
+                table: "DownloadStatuses",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RequestFingerprint",
+                table: "QueuedDownloads");
+
+            migrationBuilder.DropColumn(
+                name: "RequestFingerprint",
+                table: "DownloadStatuses");
+        }
+    }
+}

--- a/Octans.Data/Models/DownloadFailureCategory.cs
+++ b/Octans.Data/Models/DownloadFailureCategory.cs
@@ -7,5 +7,6 @@ public enum DownloadFailureCategory
     Network,
     Validation,
     Filesystem,
-    SizeLimit
+    SizeLimit,
+    Authentication
 }

--- a/Octans.Data/Models/DownloadStatus.cs
+++ b/Octans.Data/Models/DownloadStatus.cs
@@ -34,4 +34,5 @@ public class DownloadStatus
     public required string Domain { get; set; }
     public string? SourceType { get; set; }
     public string? SourceId { get; set; }
+    public string? RequestFingerprint { get; set; }
 }

--- a/Octans.Data/Models/QueuedDownload.cs
+++ b/Octans.Data/Models/QueuedDownload.cs
@@ -17,4 +17,5 @@ public class QueuedDownload
     public required string Domain { get; set; }
     public string? SourceType { get; set; }
     public string? SourceId { get; set; }
+    public string? RequestFingerprint { get; set; }
 }

--- a/Octans.Tests/Downloads/DownloadServiceTests.cs
+++ b/Octans.Tests/Downloads/DownloadServiceTests.cs
@@ -24,6 +24,7 @@ public class DownloadServiceTests
             _mockStateService,
             _activeDownloads,
             _completionNotifier,
+            new DownloadRequestHeaderProvider(Microsoft.Extensions.Options.Options.Create(new DownloadManagerOptions())),
             timeProvider,
             NullLogger<DownloadLifecycleService>.Instance);
 
@@ -93,7 +94,8 @@ public class DownloadServiceTests
             ds.State == DownloadState.Queued &&
             ds.Domain == "example.com" &&
             ds.SourceType == request.SourceType &&
-            ds.SourceId == request.SourceId));
+            ds.SourceId == request.SourceId &&
+            ds.RequestFingerprint != null));
     }
 
     [Fact]

--- a/Octans.Tests/Downloads/HttpDownloaderTests.cs
+++ b/Octans.Tests/Downloads/HttpDownloaderTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions.TestingHelpers;
+using System.Collections.ObjectModel;
 using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -59,6 +60,7 @@ public class HttpDownloaderTests
             _activeDownloads,
             _hostCircuitRegistry,
             factory,
+            new DownloadRequestHeaderProvider(Options.Create(options ?? new DownloadManagerOptions())),
             _fileSystem,
             new DownloadStagingPaths(_fileSystem),
             _timeProvider,
@@ -560,6 +562,61 @@ public class HttpDownloaderTests
             Arg.Is<DownloadTerminalUpdate>(update => update.ResponseContentType == "application/octet-stream"));
     }
 
+
+    [Fact]
+    public async Task ProcessDownloadAsync_AppliesDomainSpecificHeaders()
+    {
+        var options = new DownloadManagerOptions();
+        options.RequestHeaders.DefaultUserAgent = "Octans-Test/1.0";
+        options.RequestHeaders.Domains["example.com"] = new()
+        {
+            UserAgent = "ExampleBot/2.0",
+            Authorization = "Bearer secret",
+            Cookie = "session=abc"
+        };
+        options.RequestHeaders.Domains["example.com"].Headers["X-Source"] = "configured";
+
+        var sut = CreateDownloader(options);
+        var downloadId = Guid.NewGuid();
+        var destinationPath = "/downloads/test.txt";
+        var download = CreateDownload(downloadId, destinationPath);
+        _messageHandler.ResponseToReturn = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("hello")
+        };
+
+        await sut.ProcessDownloadAsync(download, _cts.Token);
+
+        var request = Assert.Single(_messageHandler.Requests);
+        Assert.Equal("ExampleBot/2.0", request.Headers.UserAgent.ToString());
+        Assert.Equal("Bearer secret", Assert.Single(request.Headers.GetValues("Authorization")));
+        Assert.Equal("session=abc", Assert.Single(request.Headers.GetValues("Cookie")));
+        Assert.Equal("configured", Assert.Single(request.Headers.GetValues("X-Source")));
+    }
+
+    [Fact]
+    public async Task ProcessDownloadAsync_WhenRequiredCredentialsAreMissing_FailsWithoutHttpRequest()
+    {
+        var options = new DownloadManagerOptions();
+        options.RequestHeaders.Domains["example.com"] = new();
+        options.RequestHeaders.Domains["example.com"].RequiredHeaders.Add("Authorization");
+        var sut = CreateDownloader(options);
+        var downloadId = Guid.NewGuid();
+        var download = CreateDownload(downloadId, "/downloads/test.txt");
+
+        await sut.ProcessDownloadAsync(download, _cts.Token);
+
+        Assert.Empty(_messageHandler.Requests);
+        await _lifecycle.Received(1).MarkFailedAsync(
+            downloadId,
+            Arg.Is<string>(message =>
+                message.Contains("Authorization") &&
+                !message.Contains("secret", StringComparison.OrdinalIgnoreCase)),
+            DownloadFailureCategory.Authentication,
+            DownloadTerminalOutcome.ValidationFailed,
+            validationMessage: Arg.Is<string>(message => message.Contains("Authorization")));
+    }
+
     private static QueuedDownload CreateDownload(Guid downloadId, string destinationPath)
     {
         return new()
@@ -611,11 +668,13 @@ public class TestHttpMessageHandler : HttpMessageHandler
     public bool WaitForCancellation { get; set; }
     public TaskCompletionSource RequestStarted { get; } =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public Collection<HttpRequestMessage> Requests { get; } = [];
 
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
+        Requests.Add(request);
         RequestStarted.TrySetResult();
 
         if (WaitForCancellation)


### PR DESCRIPTION
### Motivation
- Support authenticated or customized HTTP requests for downloads and downloader resolution by allowing per-domain and global request header configuration. 
- Ensure downloads that require credentials fail early with a clear authentication failure instead of issuing a request. 
- Distinguish identical URLs that require different request-affecting headers by generating and persisting a request fingerprint.

### Description
- Add `DownloadRequestHeaderOptions` and `DownloadDomainRequestHeaderOptions` to `DownloadManagerOptions` to configure default and per-domain headers, required headers, and custom headers. 
- Implement `DownloadRequestHeaderProvider` (`IDownloadRequestHeaderProvider`) to compute effective headers for a URI, validate required headers, redact sensitive values, and produce a deterministic `RequestFingerprint` (SHA256 of URL + headers). 
- Wire the provider into DI via `AddDownloadManager`, apply headers through the named `DownloadClient` for `HttpDownloader` and the downloader HTML resolver, and call `ApplyHeaders` before sending requests. 
- Introduce `MissingDownloadCredentialsException` to represent missing required headers and map it to a new `DownloadFailureCategory.Authentication` when marking failures. 
- Persist `RequestFingerprint` on `QueuedDownload` and `DownloadStatus` and generate it when queuing downloads in `DownloadLifecycleService`, with an EF migration `AddDownloadRequestFingerprint`. 
- Update `DownloadStatusTracker`, `DatabaseDownloadQueue`, `DownloaderService`, `HttpDownloader`, and tests to use the new provider and fingerprint fields. 
- Add tests verifying domain-specific header application, that missing required credentials fail without issuing HTTP requests, and that queued downloads include a request fingerprint.

### Testing
- Ran build: `/root/.dotnet/dotnet build` and verified the solution builds successfully (no errors). 
- Generated migration: `dotnet-ef migrations add AddDownloadRequestFingerprint --project Octans.Data --startup-project Octans.Data` and committed the migration files. 
- Ran unit tests: `/root/.dotnet/dotnet test`, which completed successfully; test summary: Passed 214, Failed 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072a1ecb44833186d2263bd68ca68a)