### PR TITLE
Coalesce duplicate in-flight downloads

### DIFF
--- a/Octans.Core/Downloads/DownloadServiceExtensions.cs
+++ b/Octans.Core/Downloads/DownloadServiceExtensions.cs
@@ -23,6 +23,7 @@ public static class DownloadServiceExtensions
 
         services.TryAddSingleton<IDownloadStateService, DownloadStatusTracker>();
         services.TryAddSingleton<IActiveDownloadRegistry, ActiveDownloadRegistry>();
+        services.TryAddSingleton<IInFlightDownloadCoordinator, InFlightDownloadCoordinator>();
         services.TryAddSingleton<IDownloadCompletionNotifier, NoOpDownloadCompletionNotifier>();
         services.TryAddSingleton<IDownloadJobResultService, DownloadJobResultService>();
         services.TryAddSingleton<IDownloadBandwidthGate, NoOpDownloadBandwidthGate>();

--- a/Octans.Core/Downloads/DownloadStagingPaths.cs
+++ b/Octans.Core/Downloads/DownloadStagingPaths.cs
@@ -1,4 +1,6 @@
 using System.IO.Abstractions;
+using System.Security.Cryptography;
+using System.Text;
 using Octans.Data.Models;
 
 namespace Octans.Core.Downloads;
@@ -22,19 +24,39 @@ public sealed class DownloadStagingPaths(IFileSystem fileSystem)
 
     public string PrepareFreshStagingPath(QueuedDownload download)
     {
+        var stagingPath = GetStagingPath(download);
+        PrepareFreshStagingPath(download.DestinationPath, stagingPath);
+        return stagingPath;
+    }
+
+    public string GetSharedStagingPath(QueuedDownload download, string deduplicationKey)
+    {
         var destinationDirectory = GetDestinationDirectory(download.DestinationPath);
         var stagingDirectory = fileSystem.Path.Combine(destinationDirectory, StagingDirectoryName);
+        var keyHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(deduplicationKey)));
+        return fileSystem.Path.Combine(stagingDirectory, $"shared-{keyHash}.part");
+    }
+
+    public string PrepareFreshSharedStagingPath(QueuedDownload download, string deduplicationKey)
+    {
+        var stagingPath = GetSharedStagingPath(download, deduplicationKey);
+        PrepareFreshStagingPath(download.DestinationPath, stagingPath);
+        return stagingPath;
+    }
+
+    private void PrepareFreshStagingPath(string destinationPath, string stagingPath)
+    {
+        var destinationDirectory = GetDestinationDirectory(destinationPath);
+        var stagingDirectory = fileSystem.Path.GetDirectoryName(stagingPath) ??
+                               throw new InvalidOperationException("Download staging path must include a directory.");
 
         fileSystem.Directory.CreateDirectory(destinationDirectory);
         fileSystem.Directory.CreateDirectory(stagingDirectory);
 
-        var stagingPath = GetStagingPath(download);
         if (fileSystem.File.Exists(stagingPath))
         {
             fileSystem.File.Delete(stagingPath);
         }
-
-        return stagingPath;
     }
 
     public void DeleteStagingFile(Guid downloadId, string destinationPath)

--- a/Octans.Core/Downloads/HttpDownloader.cs
+++ b/Octans.Core/Downloads/HttpDownloader.cs
@@ -19,6 +19,7 @@ public class HttpDownloader(
     IDownloadStateService stateService,
     IDownloadLifecycleService lifecycle,
     IActiveDownloadRegistry activeDownloads,
+    IInFlightDownloadCoordinator inFlightDownloads,
     IDownloadHostCircuitRegistry hostCircuitRegistry,
     IHttpClientFactory httpClientFactory,
     IDownloadRequestHeaderProvider requestHeaderProvider,
@@ -39,7 +40,7 @@ public class HttpDownloader(
 
         try
         {
-            await ProcessCore(download, downloadId, combinedToken);
+            await ProcessCore(download, downloadId, globalCancellation, downloadToken);
         }
         catch (OperationCanceledException)
             when (combinedToken.IsCancellationRequested && !globalCancellation.IsCancellationRequested)
@@ -128,7 +129,11 @@ public class HttpDownloader(
         }
     }
 
-    private async Task ProcessCore(QueuedDownload download, Guid downloadId, CancellationToken combinedToken)
+    private async Task ProcessCore(
+        QueuedDownload download,
+        Guid downloadId,
+        CancellationToken globalCancellation,
+        CancellationToken downloadToken)
     {
         var started = await lifecycle.MarkInProgressAsync(downloadId);
         if (!started)
@@ -139,7 +144,35 @@ public class HttpDownloader(
 
         logger.LogInformation("Starting download: {Url} -> {Path}", download.Url, download.DestinationPath);
 
-        var stagingPath = stagingPaths.PrepareFreshStagingPath(download);
+        var deduplicationKey = GetDeduplicationKey(download);
+        var stagingPath = stagingPaths.GetSharedStagingPath(download, deduplicationKey);
+        await using var lease = inFlightDownloads.JoinOrStart(
+            deduplicationKey,
+            stagingPath,
+            (_, transferCancellation) => TransferToSharedStagingFile(download, deduplicationKey, globalCancellation, transferCancellation));
+
+        try
+        {
+            var result = await lease.TransferTask.WaitAsync(downloadToken);
+            await FinalizeSharedDownloadAsync(download, result, lease, downloadToken);
+        }
+        catch (OperationCanceledException) when (downloadToken.IsCancellationRequested && !globalCancellation.IsCancellationRequested)
+        {
+            lease.ParticipantCanceled();
+            throw;
+        }
+    }
+
+    private async Task<SharedDownloadResult> TransferToSharedStagingFile(
+        QueuedDownload download,
+        string deduplicationKey,
+        CancellationToken globalCancellation,
+        CancellationToken transferCancellation)
+    {
+        var stagingPath = stagingPaths.PrepareFreshSharedStagingPath(download, deduplicationKey);
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(globalCancellation, transferCancellation);
+        var combinedToken = linkedCts.Token;
 
         using var httpClient = httpClientFactory.CreateClient("DownloadClient");
         httpClient.Timeout = TimeSpan.FromHours(2); // Long timeout for large files
@@ -173,6 +206,8 @@ public class HttpDownloader(
                     contentTypeValidation.ResponseContentType);
             }
 
+            _ = DownloadHashValidator.Create(download.ExpectedHashes);
+
             var totalBytes = response.Content.Headers.ContentLength ?? -1;
             var maxDownloadSizeBytes = GetMaxDownloadSizeBytes(download);
             if (totalBytes >= 0 && maxDownloadSizeBytes is { } maxBytes && totalBytes > maxBytes)
@@ -182,12 +217,8 @@ public class HttpDownloader(
 
             if (totalBytes >= 0)
             {
-                diskSpaceGuard.EnsureSufficientSpace(download.DestinationPath, totalBytes);
+                diskSpaceGuard.EnsureSufficientSpace(stagingPath, totalBytes);
             }
-
-            await stateService.UpdateProgress(downloadId, 0, totalBytes, 0);
-
-            var hashValidators = DownloadHashValidator.Create(download.ExpectedHashes);
 
             var (bytesDownloaded, startTime) = await StreamToStagingFile(
                 download,
@@ -201,36 +232,92 @@ public class HttpDownloader(
                     $"Content-Length mismatch: download ended after {bytesDownloaded} bytes, but the server reported {totalBytes} bytes.");
             }
 
-            hashValidators.Validate(fileSystem, stagingPath);
-
-            stagingPaths.MoveToDestination(download, stagingPath);
-
-            // Final progress update and state change
-            var totalElapsed = timeProvider.GetElapsedTime(startTime);
-
-            await stateService.UpdateProgress(downloadId,
+            return new(
+                stagingPath,
                 bytesDownloaded,
                 totalBytes,
-                bytesDownloaded / totalElapsed.TotalSeconds);
-
-            await lifecycle.MarkCompletedAsync(downloadId, new()
-            {
-                Outcome = DownloadTerminalOutcome.Completed,
-                HttpStatusCode = (int)response.StatusCode,
-                ResponseContentType = response.Content.Headers.ContentType?.ToString(),
-                ResponseETag = response.Headers.ETag?.ToString(),
-                ResponseLastModified = response.Content.Headers.LastModified
-            });
-
-            logger.LogInformation("Download completed: {Url} -> {Path}, {Bytes} bytes",
-                download.Url,
-                download.DestinationPath,
-                bytesDownloaded);
+                timeProvider.GetElapsedTime(startTime),
+                (int)response.StatusCode,
+                response.Content.Headers.ContentType?.ToString(),
+                response.Headers.ETag?.ToString(),
+                response.Content.Headers.LastModified);
         }
         catch
         {
-            DeleteStagingFileBestEffort(downloadId, download.DestinationPath);
+            DeleteStagingFileBestEffort(stagingPath);
             throw;
+        }
+    }
+
+    private async Task FinalizeSharedDownloadAsync(
+        QueuedDownload download,
+        SharedDownloadResult result,
+        InFlightDownloadLease lease,
+        CancellationToken downloadToken)
+    {
+        var parsedContentType = System.Net.Http.Headers.MediaTypeHeaderValue.TryParse(
+            result.ResponseContentType,
+            out var mediaTypeHeader)
+            ? mediaTypeHeader
+            : null;
+        var contentTypeValidation = DownloadContentTypeValidator.Validate(
+            download,
+            parsedContentType,
+            options.Value.ContentTypeValidation);
+        if (!contentTypeValidation.Accepted)
+        {
+            throw new DownloadContentTypeException(
+                contentTypeValidation.Message ?? "Download content type did not match expectations.",
+                contentTypeValidation.ResponseContentType);
+        }
+
+        var hashValidators = DownloadHashValidator.Create(download.ExpectedHashes);
+        hashValidators.Validate(fileSystem, result.StagingPath);
+
+        if (result.TotalBytes >= 0)
+        {
+            diskSpaceGuard.EnsureSufficientSpace(download.DestinationPath, result.TotalBytes);
+        }
+
+        await lease.RunFinalizerAsync(() => CopySharedStagingToDestinationAsync(download, result), downloadToken);
+
+        await stateService.UpdateProgress(download.Id,
+            result.BytesDownloaded,
+            result.TotalBytes,
+            result.Elapsed.TotalSeconds <= 0 ? 0 : result.BytesDownloaded / result.Elapsed.TotalSeconds);
+
+        await lifecycle.MarkCompletedAsync(download.Id, new()
+        {
+            Outcome = DownloadTerminalOutcome.Completed,
+            HttpStatusCode = result.HttpStatusCode,
+            ResponseContentType = result.ResponseContentType,
+            ResponseETag = result.ResponseETag,
+            ResponseLastModified = result.ResponseLastModified
+        });
+
+        logger.LogInformation("Download completed: {Url} -> {Path}, {Bytes} bytes",
+            download.Url,
+            download.DestinationPath,
+            result.BytesDownloaded);
+    }
+
+    private async Task CopySharedStagingToDestinationAsync(QueuedDownload download, SharedDownloadResult result)
+    {
+        var destinationDirectory = fileSystem.Path.GetDirectoryName(download.DestinationPath) ??
+                                   throw new InvalidOperationException("Download destination must include a directory.");
+        fileSystem.Directory.CreateDirectory(destinationDirectory);
+
+        try
+        {
+            await using var source = fileSystem.File.OpenRead(result.StagingPath);
+            await using var destination = fileSystem.File.Create(download.DestinationPath);
+            await source.CopyToAsync(destination);
+        }
+        catch (IOException ex)
+        {
+            throw new DownloadDiskSpaceException(
+                "Download failed while writing to disk. The destination may not have enough free space.",
+                ex);
         }
     }
 
@@ -262,7 +349,7 @@ public class HttpDownloader(
 
             await bandwidthGate.WaitForBytesAsync(download.Domain, bytesRead, combinedToken);
             diskSpaceGuard.EnsureSufficientSpace(
-                download.DestinationPath,
+                stagingPath,
                 GetRequiredBytesBeforeWrite(response.Content.Headers.ContentLength, bytesDownloaded, bytesRead));
 
             try
@@ -458,6 +545,48 @@ public class HttpDownloader(
         {
             logger.LogWarning(ex, "Failed to delete staging file for {DestinationPath}", destinationPath);
         }
+    }
+
+    private void DeleteStagingFileBestEffort(string stagingPath)
+    {
+        try
+        {
+            if (fileSystem.File.Exists(stagingPath))
+            {
+                fileSystem.File.Delete(stagingPath);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to delete staging file {StagingPath}", stagingPath);
+        }
+    }
+
+
+    private string GetDeduplicationKey(QueuedDownload download)
+    {
+        if (!string.IsNullOrWhiteSpace(download.RequestFingerprint))
+        {
+            return download.RequestFingerprint;
+        }
+
+        var uri = new Uri(download.Url);
+        return requestHeaderProvider.GetRequestFingerprint(NormalizeUri(uri));
+    }
+
+    private static Uri NormalizeUri(Uri uri)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            Host = uri.IdnHost.ToLowerInvariant()
+        };
+
+        if (uri.IsDefaultPort)
+        {
+            builder.Port = -1;
+        }
+
+        return builder.Uri;
     }
 
     private static DownloadFailureCategory CategorizeFailure(Exception ex)

--- a/Octans.Core/Downloads/InFlightDownloadCoordinator.cs
+++ b/Octans.Core/Downloads/InFlightDownloadCoordinator.cs
@@ -1,0 +1,210 @@
+using System.Collections.Concurrent;
+using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Octans.Core.Downloads;
+
+public interface IInFlightDownloadCoordinator
+{
+    InFlightDownloadLease JoinOrStart(
+        string deduplicationKey,
+        string stagingPath,
+        Func<string, CancellationToken, Task<SharedDownloadResult>> startTransfer);
+}
+
+public sealed class InFlightDownloadCoordinator(
+    IFileSystem fileSystem,
+    ILogger<InFlightDownloadCoordinator> logger) : IInFlightDownloadCoordinator
+{
+    private readonly ConcurrentDictionary<string, SharedDownload> _downloads = new(StringComparer.Ordinal);
+
+    public InFlightDownloadLease JoinOrStart(
+        string deduplicationKey,
+        string stagingPath,
+        Func<string, CancellationToken, Task<SharedDownloadResult>> startTransfer)
+    {
+        var shared = _downloads.GetOrAdd(
+            deduplicationKey,
+            key => new SharedDownload(
+                key,
+                stagingPath,
+                startTransfer,
+                fileSystem,
+                logger,
+                Remove));
+
+        shared.AddParticipant();
+        return new(shared);
+    }
+
+    private void Remove(string key, SharedDownload shared)
+    {
+        _downloads.TryRemove(new KeyValuePair<string, SharedDownload>(key, shared));
+    }
+}
+
+public sealed class InFlightDownloadLease(SharedDownload shared) : IAsyncDisposable
+{
+    private bool _disposed;
+
+    public Task<SharedDownloadResult> TransferTask => shared.TransferTask;
+
+    public Task RunFinalizerAsync(Func<Task> finalizer, CancellationToken cancellationToken)
+    {
+        return shared.RunFinalizerAsync(finalizer, cancellationToken);
+    }
+
+    public void ParticipantCanceled()
+    {
+        shared.ParticipantCanceled();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        await shared.ReleaseParticipantAsync();
+    }
+}
+
+public sealed record SharedDownloadResult(
+    string StagingPath,
+    long BytesDownloaded,
+    long TotalBytes,
+    TimeSpan Elapsed,
+    int HttpStatusCode,
+    string? ResponseContentType,
+    string? ResponseETag,
+    DateTimeOffset? ResponseLastModified);
+
+public sealed class SharedDownload : IDisposable
+{
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly SemaphoreSlim _finalizationLock = new(1, 1);
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger _logger;
+    private readonly Action<string, SharedDownload> _remove;
+    private int _participantCount;
+    private int _cleanupStarted;
+
+    public SharedDownload(
+        string key,
+        string stagingPath,
+        Func<string, CancellationToken, Task<SharedDownloadResult>> startTransfer,
+        IFileSystem fileSystem,
+        ILogger logger,
+        Action<string, SharedDownload> remove)
+    {
+        Key = key;
+        StagingPath = stagingPath;
+        _fileSystem = fileSystem;
+        _logger = logger;
+        _remove = remove;
+        TransferTask = Task.Run(() => startTransfer(stagingPath, _cancellation.Token));
+    }
+
+    public string Key { get; }
+    public string StagingPath { get; }
+    public Task<SharedDownloadResult> TransferTask { get; }
+
+    public void AddParticipant()
+    {
+        Interlocked.Increment(ref _participantCount);
+    }
+
+    public void ParticipantCanceled()
+    {
+        if (Volatile.Read(ref _participantCount) <= 1)
+        {
+            _cancellation.Cancel();
+        }
+    }
+
+    public async Task RunFinalizerAsync(Func<Task> finalizer, CancellationToken cancellationToken)
+    {
+        await _finalizationLock.WaitAsync(cancellationToken);
+        try
+        {
+            await finalizer();
+        }
+        finally
+        {
+            _finalizationLock.Release();
+        }
+    }
+
+    public async ValueTask ReleaseParticipantAsync()
+    {
+        if (Interlocked.Decrement(ref _participantCount) > 0)
+        {
+            return;
+        }
+
+        await CleanupAsync();
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _cleanupStarted, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            _cancellation.Cancel();
+            if (_fileSystem.File.Exists(StagingPath))
+            {
+                _fileSystem.File.Delete(StagingPath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to dispose shared download {StagingPath}", StagingPath);
+        }
+        finally
+        {
+            _remove(Key, this);
+            _finalizationLock.Dispose();
+            _cancellation.Dispose();
+        }
+    }
+
+    private async ValueTask CleanupAsync()
+    {
+        if (Interlocked.Exchange(ref _cleanupStarted, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            await _cancellation.CancelAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        try
+        {
+            if (_fileSystem.File.Exists(StagingPath))
+            {
+                _fileSystem.File.Delete(StagingPath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete shared download staging file {StagingPath}", StagingPath);
+        }
+        finally
+        {
+            _remove(Key, this);
+            _finalizationLock.Dispose();
+            _cancellation.Dispose();
+        }
+    }
+}

--- a/Octans.Core/Downloads/README.md
+++ b/Octans.Core/Downloads/README.md
@@ -74,3 +74,11 @@ hosts or callers.
 Bandwidth limiting is byte-aware. The queue does not block future downloads
 based on completed download totals; active streams are paced through
 `IDownloadBandwidthGate`.
+
+In-flight downloads are coalesced by request fingerprint, which is derived from
+the normalized GET URL plus configured request headers and credential-bearing
+context. Jobs that request the same transfer share one HTTP stream into a shared
+staging file; each job still completes independently, validates its own content
+expectations, and copies the staged bytes to its requested destination. Canceling
+one interested job only cancels the shared stream when no other interested jobs
+remain.

--- a/Octans.Tests/Downloads/HttpDownloaderTests.cs
+++ b/Octans.Tests/Downloads/HttpDownloaderTests.cs
@@ -58,6 +58,7 @@ public class HttpDownloaderTests
             _stateService,
             _lifecycle,
             _activeDownloads,
+            new InFlightDownloadCoordinator(_fileSystem, NullLogger<InFlightDownloadCoordinator>.Instance),
             _hostCircuitRegistry,
             factory,
             new DownloadRequestHeaderProvider(Options.Create(options ?? new DownloadManagerOptions())),
@@ -99,6 +100,70 @@ public class HttpDownloaderTests
                 update.Outcome == DownloadTerminalOutcome.Completed &&
                 update.HttpStatusCode == 200));
         await _bandwidthGate.Received(2).WaitForBytesAsync("example.com", Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+
+    [Fact]
+    public async Task ProcessDownloadAsync_WhenDuplicateUrlIsAlreadyInFlight_ReusesSingleHttpTransferForBothDestinations()
+    {
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var first = CreateDownload(firstId, "/downloads/first.txt");
+        var second = CreateDownload(secondId, "/downloads/second.txt");
+        var content = new PausingReadContent("hello");
+        _messageHandler.ResponseToReturn = new(HttpStatusCode.OK)
+        {
+            Content = content
+        };
+
+        var firstTask = _sut.ProcessDownloadAsync(first, _cts.Token);
+        await content.SecondReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var secondTask = _sut.ProcessDownloadAsync(second, _cts.Token);
+
+        await Task.Delay(100);
+        Assert.Single(_messageHandler.Requests);
+
+        content.ReleaseSecondRead();
+        await Task.WhenAll(firstTask, secondTask);
+
+        Assert.Single(_messageHandler.Requests);
+        Assert.Equal("hello", await _fileSystem.File.ReadAllTextAsync(first.DestinationPath));
+        Assert.Equal("hello", await _fileSystem.File.ReadAllTextAsync(second.DestinationPath));
+        await _lifecycle.Received(1).MarkCompletedAsync(firstId, Arg.Any<DownloadTerminalUpdate>());
+        await _lifecycle.Received(1).MarkCompletedAsync(secondId, Arg.Any<DownloadTerminalUpdate>());
+    }
+
+    [Fact]
+    public async Task ProcessDownloadAsync_WhenOneDuplicateIsCanceled_SharedTransferContinuesForRemainingDownload()
+    {
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var first = CreateDownload(firstId, "/downloads/first.txt");
+        var second = CreateDownload(secondId, "/downloads/second.txt");
+        using var firstCts = new CancellationTokenSource();
+        using var secondCts = new CancellationTokenSource();
+        _activeDownloads.GetToken(firstId).Returns(firstCts.Token);
+        _activeDownloads.GetToken(secondId).Returns(secondCts.Token);
+        var content = new PausingReadContent("hello");
+        _messageHandler.ResponseToReturn = new(HttpStatusCode.OK)
+        {
+            Content = content
+        };
+
+        var firstTask = _sut.ProcessDownloadAsync(first, _cts.Token);
+        await content.SecondReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var secondTask = _sut.ProcessDownloadAsync(second, _cts.Token);
+        await firstCts.CancelAsync();
+
+        await firstTask;
+        content.ReleaseSecondRead();
+        await secondTask;
+
+        Assert.Single(_messageHandler.Requests);
+        Assert.False(_fileSystem.File.Exists(first.DestinationPath));
+        Assert.Equal("hello", await _fileSystem.File.ReadAllTextAsync(second.DestinationPath));
+        await _lifecycle.Received(1).MarkCanceledAsync(firstId);
+        await _lifecycle.Received(1).MarkCompletedAsync(secondId, Arg.Any<DownloadTerminalUpdate>());
     }
 
     [Fact]
@@ -718,8 +783,12 @@ public class HttpDownloaderTests
     {
         var destinationDirectory = _fileSystem.Path.GetDirectoryName(destinationPath) ??
                                    throw new InvalidOperationException();
+        var provider = new DownloadRequestHeaderProvider(Options.Create(new DownloadManagerOptions()));
+        var key = provider.GetRequestFingerprint(new Uri("https://example.com/test.txt"));
+        var keyHash = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(key)));
 
-        return _fileSystem.Path.Combine(destinationDirectory, ".octans-downloads", $"{downloadId}.part");
+        return _fileSystem.Path.Combine(destinationDirectory, ".octans-downloads", $"shared-{keyHash}.part");
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate HTTP transfers when multiple feature-level requests target the same resource so one network request can satisfy all interested callers.
- Use a deterministic deduplication key (request fingerprint / normalized URL + request headers) so requests with identical effective HTTP semantics are coalesced.
- Preserve feature-level provenance so each caller gets a terminal result and can cancel independently without inadvertently aborting remaining participants.
- Keep destination handling predictable: stream into a shared staging file and let each job validate and copy to its own destination.

### Description
- Added a new in-flight coordinator `IInFlightDownloadCoordinator` and implementation `InFlightDownloadCoordinator` to track active transfers, reference-count participants, serialize finalizers, and clean up shared staging files. (`Octans.Core/Downloads/InFlightDownloadCoordinator.cs`).
- Updated `HttpDownloader` to compute a deduplication key (use `RequestFingerprint` when present or `GetRequestFingerprint(NormalizeUri(uri))`), join or start a shared transfer via the coordinator, stream into a shared staging file, and then finalize per-job by validating hashes/content and copying the staged file to each job's destination. (`Octans.Core/Downloads/HttpDownloader.cs`).
- Added shared staging helpers in `DownloadStagingPaths` (`GetSharedStagingPath`, `PrepareFreshSharedStagingPath`) and adjusted staging/disk-space checks to operate on the shared staging file while streaming. (`Octans.Core/Downloads/DownloadStagingPaths.cs`).
- Registered the coordinator in DI (`AddDownloadManager`) so the coordinator is available to `HttpDownloader`. (`Octans.Core/Downloads/DownloadServiceExtensions.cs`).
- Documented coalescing behavior and dedupe key semantics in the downloads README. (`Octans.Core/Downloads/README.md`).
- Added unit tests to assert duplicate-coalescing and cancellation semantics so concurrent duplicate submissions result in one HTTP request and both callers receive terminal results. The tests are in `Octans.Tests/Downloads/HttpDownloaderTests.cs` and exercise: `ProcessDownloadAsync_WhenDuplicateUrlIsAlreadyInFlight_ReusesSingleHttpTransferForBothDestinations` and `ProcessDownloadAsync_WhenOneDuplicateIsCanceled_SharedTransferContinuesForRemainingDownload`.

### Testing
- Ran full build with `dotnet build` and test suite with `dotnet test`; both completed successfully. The test run passed the project's tests (all tests passed).
- Executed the `HttpDownloader` unit tests to verify the new coalescing scenarios and cancellation semantics; the tests passed.
- Verified local execution of `HttpDownloader` behavior via the expanded unit tests which confirmed: a single HTTP request for concurrent duplicate submissions and correct per-job completion and cancellation handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074c80860083319582f5e5f5b4f4fd)