### PR TITLE
[codex] Add download observability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,10 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
   </ItemGroup>
 

--- a/Octans.Client/ObservabilityServiceCollectionExtensions.cs
+++ b/Octans.Client/ObservabilityServiceCollectionExtensions.cs
@@ -1,0 +1,48 @@
+using Octans.Core.Http;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Octans.Client;
+
+public static class ObservabilityServiceCollectionExtensions
+{
+    public static IServiceCollection AddOctansObservability(this WebApplicationBuilder builder)
+    {
+        var serviceVersion = typeof(Program).Assembly.GetName().Version?.ToString();
+        var useOtlpExporter = builder.Configuration.GetValue<bool>("OpenTelemetry:OtlpExporter:Enabled")
+                              || !string.IsNullOrWhiteSpace(
+                                  builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(
+                serviceName: builder.Environment.ApplicationName,
+                serviceVersion: serviceVersion))
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddSource(DownloadTelemetry.ActivitySourceName)
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation();
+
+                if (useOtlpExporter)
+                {
+                    tracing.AddOtlpExporter();
+                }
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddMeter(DownloadTelemetry.MeterName)
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation();
+
+                if (useOtlpExporter)
+                {
+                    metrics.AddOtlpExporter();
+                }
+            });
+
+        return builder.Services;
+    }
+}

--- a/Octans.Client/Octans.Client.csproj
+++ b/Octans.Client/Octans.Client.csproj
@@ -22,6 +22,10 @@
     <ItemGroup>
         <PackageReference Include="MudBlazor" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
         <PackageReference Include="Swashbuckle.AspNetCore" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
         <PackageReference Include="Toolbelt.Blazor.SplitContainer" />

--- a/Octans.Client/Program.cs
+++ b/Octans.Client/Program.cs
@@ -23,6 +23,7 @@ builder.Services.ConfigureHttpJsonOptions(o =>
 builder.AddKeyProtection();
 
 builder.Services.AddMudServices();
+builder.AddOctansObservability();
 builder.Services.AddOctansClient();
 builder.Services.AddInfrastructure();
 builder.Services.AddOctansServices();

--- a/Octans.Core/Http/DatabaseDownloadQueue.cs
+++ b/Octans.Core/Http/DatabaseDownloadQueue.cs
@@ -26,15 +26,15 @@ public interface IDownloadQueue
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix")]
 public class DatabaseDownloadQueue(
     IDbContextFactory<ServerDbContext> contextFactory,
-    ILogger<DatabaseDownloadQueue> logger) : IDownloadQueue
+    ILogger<DatabaseDownloadQueue> logger,
+    DownloadTelemetry telemetry) : IDownloadQueue
 {
     public async Task<Guid> EnqueueAsync(QueuedDownload download)
     {
         using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
             ["DownloadId"] = download.Id,
-            ["Url"] = download.Url,
-            ["Domain"] = download.Domain,
+            ["OriginalHost"] = download.Domain,
             ["SourceType"] = download.SourceType,
             ["SourceId"] = download.SourceId
         });
@@ -52,6 +52,7 @@ public class DatabaseDownloadQueue(
 
         db.QueuedDownloads.Add(download);
         await db.SaveChangesAsync();
+        await RecordQueueDepthAsync(db);
 
         logger.LogDebug("Download successfully added to queue");
         return download.Id;
@@ -62,8 +63,7 @@ public class DatabaseDownloadQueue(
         using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
             ["DownloadId"] = status.Id,
-            ["Url"] = status.Url,
-            ["Domain"] = status.Domain,
+            ["OriginalHost"] = status.Domain,
             ["SourceType"] = status.SourceType,
             ["SourceId"] = status.SourceId
         });
@@ -72,6 +72,7 @@ public class DatabaseDownloadQueue(
         var exists = await db.QueuedDownloads.AnyAsync(d => d.Id == status.Id, cancellationToken);
         if (exists)
         {
+            await RecordQueueDepthAsync(db, cancellationToken);
             logger.LogDebug("Download already has a queued row");
             return;
         }
@@ -93,6 +94,7 @@ public class DatabaseDownloadQueue(
         });
 
         await db.SaveChangesAsync(cancellationToken);
+        await RecordQueueDepthAsync(db, cancellationToken);
         logger.LogInformation("Restored download to queue");
     }
 
@@ -131,6 +133,7 @@ public class DatabaseDownloadQueue(
             // Remove from queue
             db.QueuedDownloads.Remove(download);
             await db.SaveChangesAsync(cancellationToken);
+            await RecordQueueDepthAsync(db, cancellationToken);
 
             return download;
         }
@@ -145,6 +148,7 @@ public class DatabaseDownloadQueue(
 
         await using var db = await contextFactory.CreateDbContextAsync();
         var count = await db.QueuedDownloads.CountAsync();
+        await RecordQueueDepthAsync(db);
 
         logger.LogDebug("Current queue size: {Count} downloads", count);
         return count;
@@ -163,10 +167,31 @@ public class DatabaseDownloadQueue(
             logger.LogDebug("Found download in queue, removing");
             db.QueuedDownloads.Remove(download);
             await db.SaveChangesAsync();
+            await RecordQueueDepthAsync(db);
         }
         else
         {
             logger.LogDebug("Download not found in queue");
         }
+    }
+
+    private async Task RecordQueueDepthAsync(
+        ServerDbContext db,
+        CancellationToken cancellationToken = default)
+    {
+        var queueDepthByDomain = await db.QueuedDownloads
+            .GroupBy(download => download.Domain)
+            .Select(group => new
+            {
+                Domain = group.Key,
+                Count = group.Count()
+            })
+            .ToDictionaryAsync(
+                group => group.Domain,
+                group => group.Count,
+                StringComparer.OrdinalIgnoreCase,
+                cancellationToken);
+
+        telemetry.SetQueueDepth(queueDepthByDomain);
     }
 }

--- a/Octans.Core/Http/DownloadHostCircuitRegistry.cs
+++ b/Octans.Core/Http/DownloadHostCircuitRegistry.cs
@@ -19,7 +19,8 @@ public interface IDownloadHostCircuitRegistry
 /// </summary>
 public sealed class DownloadHostCircuitRegistry(
     TimeProvider timeProvider,
-    ILogger<DownloadHostCircuitRegistry> logger) : IDownloadHostCircuitRegistry
+    ILogger<DownloadHostCircuitRegistry> logger,
+    DownloadTelemetry telemetry) : IDownloadHostCircuitRegistry
 {
     private readonly Lock _lock = new();
     private readonly Dictionary<string, DateTimeOffset> _openUntilByDomain = new(StringComparer.OrdinalIgnoreCase);
@@ -68,6 +69,7 @@ public sealed class DownloadHostCircuitRegistry(
             _openUntilByDomain[normalizedDomain] = openUntil;
         }
 
+        telemetry.RecordCircuitOpened(normalizedDomain, breakDuration);
         logger.LogWarning("Opened download host circuit for {Domain} until {OpenUntil}", normalizedDomain, openUntil);
     }
 
@@ -85,6 +87,7 @@ public sealed class DownloadHostCircuitRegistry(
             _openUntilByDomain.Remove(normalizedDomain);
         }
 
+        telemetry.RecordCircuitClosed(normalizedDomain);
         logger.LogInformation("Closed download host circuit for {Domain}", normalizedDomain);
     }
 

--- a/Octans.Core/Http/DownloadLifecycleService.cs
+++ b/Octans.Core/Http/DownloadLifecycleService.cs
@@ -59,8 +59,7 @@ public sealed class DownloadLifecycleService(
         using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
             ["DownloadId"] = id,
-            ["Url"] = request.Url,
-            ["Domain"] = domain
+            ["OriginalHost"] = domain
         });
 
         logger.LogInformation("Queueing download for {Filename}", filename);

--- a/Octans.Core/Http/DownloadServiceExtensions.cs
+++ b/Octans.Core/Http/DownloadServiceExtensions.cs
@@ -36,6 +36,7 @@ public static class DownloadServiceExtensions
         services.TryAddSingleton<IDownloadDiskSpaceGuard, DownloadDiskSpaceGuard>();
         services.TryAddSingleton<IDownloadHostCircuitRegistry, DownloadHostCircuitRegistry>();
         services.TryAddSingleton<IDownloadRequestHeaderProvider, DownloadRequestHeaderProvider>();
+        services.TryAddSingleton<DownloadTelemetry>();
         services.TryAddSingleton<DownloadStagingPaths>();
         services.TryAddSingleton<IDownloadLifecycleService, DownloadLifecycleService>();
         services.TryAddSingleton<HttpDownloader>();
@@ -64,6 +65,16 @@ public static class DownloadServiceExtensions
         resilienceOptions.Retry.UseJitter = true;
 
         var circuitRegistry = provider.GetRequiredService<IDownloadHostCircuitRegistry>();
+        var telemetry = provider.GetRequiredService<DownloadTelemetry>();
+
+        resilienceOptions.Retry.OnRetry = args =>
+        {
+            var domain = args.Context.GetRequestMessage()?.RequestUri?.Host;
+            telemetry.RecordRetry(domain, args.AttemptNumber, args.RetryDelay);
+
+            return default;
+        };
+
         resilienceOptions.CircuitBreaker.FailureRatio = breakerOptions.FailureRatio;
         resilienceOptions.CircuitBreaker.MinimumThroughput = breakerOptions.MinimumThroughput;
         resilienceOptions.CircuitBreaker.SamplingDuration = breakerOptions.SamplingDuration;

--- a/Octans.Core/Http/DownloadStatusTracker.cs
+++ b/Octans.Core/Http/DownloadStatusTracker.cs
@@ -250,8 +250,7 @@ public class DownloadStatusTracker(
         using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
             ["DownloadId"] = status.Id,
-            ["Url"] = status.Url,
-            ["Domain"] = status.Domain
+            ["OriginalHost"] = status.Domain
         });
 
         await using var db = await contextFactory.CreateDbContextAsync();

--- a/Octans.Core/Http/DownloadTelemetry.cs
+++ b/Octans.Core/Http/DownloadTelemetry.cs
@@ -1,0 +1,300 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Octans.Data.Models;
+
+namespace Octans.Core.Http;
+
+/// <summary>
+/// Emits Octans-owned download telemetry. HTTP request spans and low-level HTTP
+/// metrics come from the standard HttpClient instrumentation.
+/// </summary>
+public sealed class DownloadTelemetry : IDisposable
+{
+    public const string ActivitySourceName = "Octans.Core.Http.Downloads";
+    public const string MeterName = "Octans.Core.Http.Downloads";
+
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    private readonly Meter _meter = new(MeterName);
+    private readonly Counter<long> _downloadsStarted;
+    private readonly Counter<long> _downloadsCompleted;
+    private readonly Counter<long> _downloadsFailed;
+    private readonly Counter<long> _downloadsCanceled;
+    private readonly Counter<long> _bytesTransferred;
+    private readonly Counter<long> _retries;
+    private readonly Counter<long> _circuitTransitions;
+    private readonly Histogram<double> _downloadDuration;
+    private readonly ObservableGauge<int> _queueDepth;
+    private readonly ObservableGauge<int> _activeDownloads;
+    private readonly object _queueDepthLock = new();
+    private readonly object _activeDownloadsLock = new();
+    private Dictionary<string, int> _queueDepthByDomain = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, int> _activeDownloadsByDomain = new(StringComparer.OrdinalIgnoreCase);
+
+    public DownloadTelemetry()
+    {
+        _downloadsStarted = _meter.CreateCounter<long>(
+            "octans.downloads.started",
+            description: "Number of downloads that Octans started processing.");
+        _downloadsCompleted = _meter.CreateCounter<long>(
+            "octans.downloads.completed",
+            description: "Number of downloads that completed successfully.");
+        _downloadsFailed = _meter.CreateCounter<long>(
+            "octans.downloads.failed",
+            description: "Number of downloads that reached a failed terminal state.");
+        _downloadsCanceled = _meter.CreateCounter<long>(
+            "octans.downloads.canceled",
+            description: "Number of downloads canceled while Octans was processing them.");
+        _bytesTransferred = _meter.CreateCounter<long>(
+            "octans.downloads.bytes",
+            unit: "By",
+            description: "Payload bytes transferred by completed downloads.");
+        _retries = _meter.CreateCounter<long>(
+            "octans.downloads.retries",
+            description: "Retry attempts made by the download HTTP resilience pipeline.");
+        _circuitTransitions = _meter.CreateCounter<long>(
+            "octans.downloads.circuit.transitions",
+            description: "Host circuit breaker open and close transitions.");
+        _downloadDuration = _meter.CreateHistogram<double>(
+            "octans.downloads.duration",
+            unit: "s",
+            description: "Elapsed time spent processing downloads.");
+        _queueDepth = _meter.CreateObservableGauge(
+            "octans.downloads.queue.depth",
+            ObserveQueueDepth,
+            description: "Queued downloads waiting for the background worker.");
+        _activeDownloads = _meter.CreateObservableGauge(
+            "octans.downloads.active",
+            ObserveActiveDownloads,
+            description: "Downloads currently being processed.");
+    }
+
+    public Activity? StartDownloadActivity(QueuedDownload download)
+    {
+        var activity = ActivitySource.StartActivity("octans.download.process", ActivityKind.Internal);
+        if (activity is null)
+        {
+            return null;
+        }
+
+        activity.SetTag("download.id", download.Id);
+        activity.SetTag("download.original_host", download.Domain);
+        activity.SetTag("download.source_type", EmptyIfNull(download.SourceType));
+        activity.SetTag("download.source_id", EmptyIfNull(download.SourceId));
+        activity.SetTag("download.destination_path", download.DestinationPath);
+
+        return activity;
+    }
+
+    public void RecordDownloadStarted(QueuedDownload download)
+    {
+        _downloadsStarted.Add(1, BuildHostTags(download.Domain, download.SourceType));
+
+        lock (_activeDownloadsLock)
+        {
+            IncrementDomain(_activeDownloadsByDomain, download.Domain);
+        }
+    }
+
+    public void RecordDownloadCompleted(
+        QueuedDownload download,
+        string? finalHost,
+        int? httpStatusCode,
+        long bytes,
+        TimeSpan duration)
+    {
+        var tags = BuildTerminalTags(
+            download.Domain,
+            finalHost,
+            download.SourceType,
+            DownloadTerminalOutcome.Completed,
+            failureCategory: null,
+            httpStatusCode);
+
+        _downloadsCompleted.Add(1, tags);
+        _bytesTransferred.Add(bytes, BuildHostTags(download.Domain, download.SourceType));
+        _downloadDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void RecordDownloadFailed(
+        QueuedDownload download,
+        string? finalHost,
+        DownloadFailureCategory failureCategory,
+        DownloadTerminalOutcome outcome,
+        int? httpStatusCode,
+        TimeSpan duration)
+    {
+        var tags = BuildTerminalTags(
+            download.Domain,
+            finalHost,
+            download.SourceType,
+            outcome,
+            failureCategory,
+            httpStatusCode);
+
+        _downloadsFailed.Add(1, tags);
+        _downloadDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void RecordDownloadCanceled(QueuedDownload download, TimeSpan duration)
+    {
+        var tags = BuildTerminalTags(
+            download.Domain,
+            finalHost: null,
+            download.SourceType,
+            DownloadTerminalOutcome.Canceled,
+            failureCategory: null,
+            httpStatusCode: null);
+
+        _downloadsCanceled.Add(1, tags);
+        _downloadDuration.Record(duration.TotalSeconds, tags);
+    }
+
+    public void RecordDownloadStopped(QueuedDownload download)
+    {
+        lock (_activeDownloadsLock)
+        {
+            DecrementDomain(_activeDownloadsByDomain, download.Domain);
+        }
+    }
+
+    public void RecordRetry(string? domain, int attemptNumber, TimeSpan retryDelay)
+    {
+        _retries.Add(1,
+            new("download.original_host", NormalizeDomain(domain)),
+            new("retry.attempt", attemptNumber),
+            new("retry.delay_ms", retryDelay.TotalMilliseconds));
+    }
+
+    public void RecordCircuitOpened(string domain, TimeSpan breakDuration)
+    {
+        _circuitTransitions.Add(1,
+            new("download.original_host", NormalizeDomain(domain)),
+            new("circuit.state", "open"),
+            new("circuit.break_duration_ms", breakDuration.TotalMilliseconds));
+    }
+
+    public void RecordCircuitClosed(string domain)
+    {
+        _circuitTransitions.Add(1,
+            new("download.original_host", NormalizeDomain(domain)),
+            new("circuit.state", "closed"));
+    }
+
+    public void SetQueueDepth(IReadOnlyDictionary<string, int> queueDepthByDomain)
+    {
+        lock (_queueDepthLock)
+        {
+            _queueDepthByDomain = new(queueDepthByDomain, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    public void Dispose()
+    {
+        _meter.Dispose();
+    }
+
+    private IEnumerable<Measurement<int>> ObserveQueueDepth()
+    {
+        lock (_queueDepthLock)
+        {
+            return BuildGaugeMeasurements(_queueDepthByDomain);
+        }
+    }
+
+    private IEnumerable<Measurement<int>> ObserveActiveDownloads()
+    {
+        lock (_activeDownloadsLock)
+        {
+            return BuildGaugeMeasurements(_activeDownloadsByDomain);
+        }
+    }
+
+    private static ReadOnlyCollection<Measurement<int>> BuildGaugeMeasurements(Dictionary<string, int> valuesByDomain)
+    {
+        var measurements = new List<Measurement<int>>
+        {
+            new(valuesByDomain.Values.Sum())
+        };
+
+        foreach (var (domain, value) in valuesByDomain)
+        {
+            measurements.Add(new(value, new KeyValuePair<string, object?>("download.original_host", domain)));
+        }
+
+        return measurements.AsReadOnly();
+    }
+
+    private static TagList BuildHostTags(string? originalHost, string? sourceType)
+    {
+        var tags = new TagList
+        {
+            { "download.original_host", NormalizeDomain(originalHost) },
+            { "download.source_type", EmptyIfNull(sourceType) }
+        };
+
+        return tags;
+    }
+
+    private static TagList BuildTerminalTags(
+        string? originalHost,
+        string? finalHost,
+        string? sourceType,
+        DownloadTerminalOutcome outcome,
+        DownloadFailureCategory? failureCategory,
+        int? httpStatusCode)
+    {
+        var tags = BuildHostTags(originalHost, sourceType);
+        tags.Add("download.final_host", NormalizeDomain(finalHost));
+        tags.Add("download.outcome", outcome.ToString());
+
+        if (failureCategory is { } category)
+        {
+            tags.Add("download.failure_category", category.ToString());
+        }
+
+        if (httpStatusCode is { } statusCode)
+        {
+            tags.Add("http.response.status_code", statusCode);
+        }
+
+        return tags;
+    }
+
+    private static void IncrementDomain(Dictionary<string, int> valuesByDomain, string? domain)
+    {
+        var normalizedDomain = NormalizeDomain(domain);
+        valuesByDomain.TryGetValue(normalizedDomain, out var count);
+        valuesByDomain[normalizedDomain] = count + 1;
+    }
+
+    private static void DecrementDomain(Dictionary<string, int> valuesByDomain, string? domain)
+    {
+        var normalizedDomain = NormalizeDomain(domain);
+        if (!valuesByDomain.TryGetValue(normalizedDomain, out var count))
+        {
+            return;
+        }
+
+        if (count <= 1)
+        {
+            valuesByDomain.Remove(normalizedDomain);
+            return;
+        }
+
+        valuesByDomain[normalizedDomain] = count - 1;
+    }
+
+    private static string NormalizeDomain(string? domain)
+    {
+        return string.IsNullOrWhiteSpace(domain)
+            ? "unknown"
+            : domain.Trim().ToLowerInvariant();
+    }
+
+    private static string EmptyIfNull(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? string.Empty : value;
+    }
+}

--- a/Octans.Core/Http/HttpDownloader.cs
+++ b/Octans.Core/Http/HttpDownloader.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.IO.Abstractions;
 using System.Security.Cryptography;
@@ -27,6 +28,7 @@ public class HttpDownloader(
     DownloadStagingPaths stagingPaths,
     TimeProvider timeProvider,
     IOptions<DownloadManagerOptions> options,
+    DownloadTelemetry telemetry,
     ILogger<HttpDownloader> logger)
 {
     /// <summary>
@@ -41,12 +43,13 @@ public class HttpDownloader(
         using var scope = logger.BeginScope(new Dictionary<string, object?>
         {
             ["DownloadId"] = downloadId,
-            ["Url"] = download.Url,
-            ["Domain"] = download.Domain,
+            ["OriginalHost"] = download.Domain,
             ["DestinationPath"] = download.DestinationPath,
             ["SourceType"] = download.SourceType,
             ["SourceId"] = download.SourceId
         });
+        using var activity = telemetry.StartDownloadActivity(download);
+        var attempt = new DownloadAttempt(download.Domain, timeProvider.GetTimestamp());
 
         // Create a combined token for this specific download
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(globalCancellation, downloadToken);
@@ -54,17 +57,24 @@ public class HttpDownloader(
 
         try
         {
-            await ProcessCore(download, downloadId, combinedToken);
+            await ProcessCore(download, downloadId, attempt, activity, combinedToken);
         }
         catch (OperationCanceledException)
             when (combinedToken.IsCancellationRequested && !globalCancellation.IsCancellationRequested)
         {
-            logger.LogInformation("Download canceled: {Url}", download.Url);
+            var duration = attempt.GetElapsed(timeProvider);
+            telemetry.RecordDownloadCanceled(download, duration);
+            SetActivityTerminalTags(activity, attempt, DownloadTerminalOutcome.Canceled);
+            logger.LogInformation(
+                "Download canceled after {DurationMs} ms with {Bytes} bytes transferred",
+                duration.TotalMilliseconds,
+                attempt.BytesTransferred);
             await lifecycle.MarkCanceledAsync(downloadId);
         }
         catch (HttpRequestException ex) when (ex.StatusCode is { } statusCode)
         {
-            logger.LogWarning(ex, "Download failed with HTTP status {StatusCode}: {Url}", (int)statusCode, download.Url);
+            attempt.HttpStatusCode ??= (int)statusCode;
+            RecordFailure(download, attempt, DownloadFailureCategory.Http, DownloadTerminalOutcome.TerminalHttpFailure, ex);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 ex.Message,
@@ -74,11 +84,11 @@ public class HttpDownloader(
         }
         catch (BrokenCircuitException ex)
         {
+            RecordFailure(download, attempt, DownloadFailureCategory.Network, DownloadTerminalOutcome.Failed, ex);
             var message = hostCircuitRegistry.TryGetOpenCircuit(download.Domain, out var openUntil)
                 ? $"Host circuit for {download.Domain} is open until {openUntil:u}."
                 : $"Host circuit for {download.Domain} is open.";
 
-            logger.LogWarning(ex, "Download skipped because host circuit is open: {Url}", download.Url);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 message,
@@ -86,7 +96,7 @@ public class HttpDownloader(
         }
         catch (MissingDownloadCredentialsException ex)
         {
-            logger.LogWarning(ex, "Download cannot start because required credentials are missing: {Url}", download.Url);
+            RecordFailure(download, attempt, DownloadFailureCategory.Authentication, DownloadTerminalOutcome.ValidationFailed, ex);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 ex.Message,
@@ -96,7 +106,7 @@ public class HttpDownloader(
         }
         catch (DownloadContentTypeException ex)
         {
-            logger.LogWarning(ex, "Download content type validation failed: {Url}", download.Url);
+            RecordFailure(download, attempt, DownloadFailureCategory.Validation, DownloadTerminalOutcome.ValidationFailed, ex);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 ex.Message,
@@ -107,7 +117,7 @@ public class HttpDownloader(
         }
         catch (DownloadSizeLimitException ex)
         {
-            logger.LogWarning(ex, "Download size limit validation failed: {Url}", download.Url);
+            RecordFailure(download, attempt, DownloadFailureCategory.SizeLimit, DownloadTerminalOutcome.ValidationFailed, ex);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 ex.Message,
@@ -117,7 +127,7 @@ public class HttpDownloader(
         }
         catch (InvalidDataException ex)
         {
-            logger.LogWarning(ex, "Download validation failed: {Url}", download.Url);
+            RecordFailure(download, attempt, DownloadFailureCategory.Validation, DownloadTerminalOutcome.ValidationFailed, ex);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 ex.Message,
@@ -127,7 +137,7 @@ public class HttpDownloader(
         }
         catch (DownloadDiskSpaceException ex)
         {
-            logger.LogWarning(ex, "Download failed because disk space was insufficient: {Url}", download.Url);
+            RecordFailure(download, attempt, DownloadFailureCategory.Filesystem, DownloadTerminalOutcome.Failed, ex);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 ex.Message,
@@ -135,33 +145,76 @@ public class HttpDownloader(
         }
         catch (Exception ex) when (ex is not OperationCanceledException || !globalCancellation.IsCancellationRequested)
         {
-            logger.LogError(ex, "Download failed: {Url}", download.Url);
+            var failureCategory = CategorizeFailure(ex);
+            RecordFailure(download, attempt, failureCategory, DownloadTerminalOutcome.Failed, ex, LogLevel.Error);
             await lifecycle.MarkFailedAsync(
                 downloadId,
                 ex.Message,
-                CategorizeFailure(ex));
+                failureCategory);
+        }
+
+        void RecordFailure(
+            QueuedDownload failedDownload,
+            DownloadAttempt failedAttempt,
+            DownloadFailureCategory failureCategory,
+            DownloadTerminalOutcome outcome,
+            Exception exception,
+            LogLevel logLevel = LogLevel.Warning)
+        {
+            var duration = failedAttempt.GetElapsed(timeProvider);
+            telemetry.RecordDownloadFailed(
+                failedDownload,
+                failedAttempt.FinalHost,
+                failureCategory,
+                outcome,
+                failedAttempt.HttpStatusCode,
+                duration);
+            SetActivityTerminalTags(activity, failedAttempt, outcome, failureCategory);
+            activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+            logger.Log(
+                logLevel,
+                exception,
+                "Download failed with category {FailureCategory}, outcome {Outcome}, HTTP status {HttpStatusCode}, final host {FinalHost}, {Bytes} bytes transferred after {DurationMs} ms",
+                failureCategory,
+                outcome,
+                failedAttempt.HttpStatusCode,
+                failedAttempt.FinalHost,
+                failedAttempt.BytesTransferred,
+                duration.TotalMilliseconds);
         }
     }
 
-    private async Task ProcessCore(QueuedDownload download, Guid downloadId, CancellationToken combinedToken)
+    private async Task ProcessCore(
+        QueuedDownload download,
+        Guid downloadId,
+        DownloadAttempt attempt,
+        Activity? activity,
+        CancellationToken combinedToken)
     {
         var started = await lifecycle.MarkInProgressAsync(downloadId);
         if (!started)
         {
-            logger.LogDebug("Skipping download because it is no longer queued: {Url}", download.Url);
+            logger.LogDebug("Skipping download because it is no longer queued");
             return;
         }
 
-        logger.LogInformation("Starting download: {Url} -> {Path}", download.Url, download.DestinationPath);
-
-        var stagingPath = stagingPaths.PrepareFreshStagingPath(download);
-        logger.LogDebug("Prepared staging path {StagingPath}", stagingPath);
-
-        using var httpClient = httpClientFactory.CreateClient("DownloadClient");
-        httpClient.Timeout = TimeSpan.FromHours(2); // Long timeout for large files
+        telemetry.RecordDownloadStarted(download);
 
         try
         {
+            logger.LogInformation(
+                "Starting download for host {OriginalHost}, source {SourceType}/{SourceId} -> {DestinationPath}",
+                download.Domain,
+                download.SourceType,
+                download.SourceId,
+                download.DestinationPath);
+
+            var stagingPath = stagingPaths.PrepareFreshStagingPath(download);
+            logger.LogDebug("Prepared staging path {StagingPath}", stagingPath);
+
+            using var httpClient = httpClientFactory.CreateClient("DownloadClient");
+            httpClient.Timeout = TimeSpan.FromHours(2); // Long timeout for large files
+
             using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(download.Url));
             requestHeaderProvider.ApplyHeaders(request);
 
@@ -169,6 +222,8 @@ public class HttpDownloader(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
                 combinedToken);
+
+            attempt.CaptureResponse(response);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -226,6 +281,7 @@ public class HttpDownloader(
                 download,
                 stagingPath,
                 response,
+                attempt,
                 maxDownloadSizeBytes,
                 combinedToken);
             if (totalBytes >= 0 && bytesDownloaded != totalBytes)
@@ -255,15 +311,32 @@ public class HttpDownloader(
                 ResponseLastModified = response.Content.Headers.LastModified
             });
 
-            logger.LogInformation("Download completed: {Url} -> {Path}, {Bytes} bytes",
-                download.Url,
-                download.DestinationPath,
-                bytesDownloaded);
+            var processDuration = attempt.GetElapsed(timeProvider);
+            telemetry.RecordDownloadCompleted(
+                download,
+                attempt.FinalHost,
+                attempt.HttpStatusCode,
+                bytesDownloaded,
+                processDuration);
+            SetActivityTerminalTags(activity, attempt, DownloadTerminalOutcome.Completed);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+
+            logger.LogInformation(
+                "Download completed with HTTP status {HttpStatusCode}, final host {FinalHost}, content type {ContentType}, {Bytes} bytes transferred after {DurationMs} ms",
+                attempt.HttpStatusCode,
+                attempt.FinalHost,
+                attempt.ResponseContentType,
+                bytesDownloaded,
+                processDuration.TotalMilliseconds);
         }
         catch
         {
             DeleteStagingFileBestEffort(downloadId, download.DestinationPath);
             throw;
+        }
+        finally
+        {
+            telemetry.RecordDownloadStopped(download);
         }
     }
 
@@ -271,6 +344,7 @@ public class HttpDownloader(
         QueuedDownload download,
         string stagingPath,
         HttpResponseMessage response,
+        DownloadAttempt attempt,
         long? maxDownloadSizeBytes,
         CancellationToken combinedToken)
     {
@@ -310,6 +384,7 @@ public class HttpDownloader(
             }
 
             bytesDownloaded += bytesRead;
+            attempt.BytesTransferred = bytesDownloaded;
 
             // Get current elapsed time in milliseconds
             var currentElapsedMs = timeProvider.GetElapsedTime(startTime).TotalMilliseconds;
@@ -502,5 +577,44 @@ public class HttpDownloader(
             UnauthorizedAccessException => DownloadFailureCategory.Filesystem,
             _ => DownloadFailureCategory.Unknown
         };
+    }
+
+    private static void SetActivityTerminalTags(
+        Activity? activity,
+        DownloadAttempt attempt,
+        DownloadTerminalOutcome outcome,
+        DownloadFailureCategory? failureCategory = null)
+    {
+        activity?.SetTag("download.final_host", attempt.FinalHost);
+        activity?.SetTag("download.outcome", outcome.ToString());
+        activity?.SetTag("download.bytes", attempt.BytesTransferred);
+
+        if (attempt.HttpStatusCode is { } statusCode)
+        {
+            activity?.SetTag("http.response.status_code", statusCode);
+        }
+
+        if (failureCategory is { } category)
+        {
+            activity?.SetTag("download.failure_category", category.ToString());
+        }
+    }
+
+    private sealed class DownloadAttempt(string originalHost, long startedAt)
+    {
+        public string OriginalHost { get; } = originalHost;
+        public string? FinalHost { get; private set; } = originalHost;
+        public int? HttpStatusCode { get; set; }
+        public string? ResponseContentType { get; private set; }
+        public long BytesTransferred { get; set; }
+
+        public TimeSpan GetElapsed(TimeProvider timeProvider) => timeProvider.GetElapsedTime(startedAt);
+
+        public void CaptureResponse(HttpResponseMessage response)
+        {
+            FinalHost = response.RequestMessage?.RequestUri?.Host ?? OriginalHost;
+            HttpStatusCode = (int)response.StatusCode;
+            ResponseContentType = response.Content.Headers.ContentType?.ToString();
+        }
     }
 }

--- a/Octans.Tests/Downloads/DatabaseDownloadQueueTests.cs
+++ b/Octans.Tests/Downloads/DatabaseDownloadQueueTests.cs
@@ -12,6 +12,7 @@ public sealed class DatabaseDownloadQueueTests : IDisposable, IAsyncDisposable
 {
     private readonly SqliteConnection _connection = new("Filename=:memory:");
     private readonly IDbContextFactory<ServerDbContext> _contextFactory = Substitute.For<IDbContextFactory<ServerDbContext>>();
+    private readonly DownloadTelemetry _telemetry = new();
     private readonly DatabaseDownloadQueue _sut;
 
     public DatabaseDownloadQueueTests()
@@ -24,7 +25,8 @@ public sealed class DatabaseDownloadQueueTests : IDisposable, IAsyncDisposable
 
         _sut = new(
             _contextFactory,
-            NullLogger<DatabaseDownloadQueue>.Instance);
+            NullLogger<DatabaseDownloadQueue>.Instance,
+            _telemetry);
     }
 
     private ServerDbContext CreateContext()
@@ -322,7 +324,15 @@ public sealed class DatabaseDownloadQueueTests : IDisposable, IAsyncDisposable
         Assert.Equal(download1.Id, result.Id);
     }
 
-    public void Dispose() => _connection.Dispose();
+    public void Dispose()
+    {
+        _telemetry.Dispose();
+        _connection.Dispose();
+    }
 
-    public async ValueTask DisposeAsync() => await _connection.DisposeAsync();
+    public async ValueTask DisposeAsync()
+    {
+        _telemetry.Dispose();
+        await _connection.DisposeAsync();
+    }
 }

--- a/Octans.Tests/Downloads/DownloadHostCircuitRegistryTests.cs
+++ b/Octans.Tests/Downloads/DownloadHostCircuitRegistryTests.cs
@@ -8,11 +8,12 @@ namespace Octans.Tests.Downloads;
 public sealed class DownloadHostCircuitRegistryTests
 {
     private readonly FakeTimeProvider _timeProvider = new(TestClock.UtcNow);
+    private readonly DownloadTelemetry _telemetry = new();
     private readonly DownloadHostCircuitRegistry _registry;
 
     public DownloadHostCircuitRegistryTests()
     {
-        _registry = new(_timeProvider, NullLogger<DownloadHostCircuitRegistry>.Instance);
+        _registry = new(_timeProvider, NullLogger<DownloadHostCircuitRegistry>.Instance, _telemetry);
     }
 
     [Fact]

--- a/Octans.Tests/Downloads/DownloadTelemetryTests.cs
+++ b/Octans.Tests/Downloads/DownloadTelemetryTests.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics.Metrics;
+using Octans.Core.Http;
+using Octans.Data.Models;
+
+namespace Octans.Tests.Downloads;
+
+public sealed class DownloadTelemetryTests
+{
+    [Fact]
+    public void RecordDownloadCompleted_EmitsHostScopedOutcomeMetrics()
+    {
+        var measurements = new List<MetricMeasurement<long>>();
+        using var listener = CreateListener(measurements);
+        listener.Start();
+
+        using var telemetry = new DownloadTelemetry();
+        var download = CreateDownload();
+
+        telemetry.RecordDownloadCompleted(
+            download,
+            finalHost: "cdn.example.com",
+            httpStatusCode: 200,
+            bytes: 1234,
+            duration: TimeSpan.FromSeconds(2));
+
+        var snapshot = measurements.ToList();
+        Assert.Contains(snapshot, measurement =>
+            measurement.Name == "octans.downloads.completed" &&
+            measurement.Value == 1 &&
+            measurement.Tags["download.original_host"] as string == "example.com" &&
+            measurement.Tags["download.final_host"] as string == "cdn.example.com" &&
+            measurement.Tags["download.source_type"] as string == "RawUrl" &&
+            Equals(measurement.Tags["http.response.status_code"], 200));
+        Assert.Contains(snapshot, measurement =>
+            measurement.Name == "octans.downloads.bytes" &&
+            measurement.Value == 1234 &&
+            measurement.Tags["download.original_host"] as string == "example.com");
+    }
+
+    [Fact]
+    public void SetQueueDepth_EmitsGlobalAndHostScopedGaugeMeasurements()
+    {
+        var measurements = new List<MetricMeasurement<int>>();
+        using var listener = CreateListener(measurements);
+        listener.Start();
+
+        using var telemetry = new DownloadTelemetry();
+
+        telemetry.SetQueueDepth(new Dictionary<string, int>
+        {
+            ["example.com"] = 2,
+            ["cdn.example.com"] = 3
+        });
+        listener.RecordObservableInstruments();
+
+        var snapshot = measurements.ToList();
+        Assert.Contains(snapshot, measurement =>
+            measurement.Name == "octans.downloads.queue.depth" &&
+            measurement.Value == 5 &&
+            !measurement.Tags.ContainsKey("download.original_host"));
+        Assert.Contains(snapshot, measurement =>
+            measurement.Name == "octans.downloads.queue.depth" &&
+            measurement.Value == 2 &&
+            measurement.Tags["download.original_host"] as string == "example.com");
+    }
+
+    private static MeterListener CreateListener<T>(List<MetricMeasurement<T>> measurements)
+        where T : struct
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == DownloadTelemetry.MeterName)
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        listener.SetMeasurementEventCallback<T>((instrument, value, tags, _) =>
+        {
+            measurements.Add(new(
+                instrument.Name,
+                value,
+                tags.ToArray().ToDictionary(
+                    tag => tag.Key,
+                    tag => tag.Value,
+                    StringComparer.Ordinal)));
+        });
+
+        return listener;
+    }
+
+    private static QueuedDownload CreateDownload()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Url = "https://example.com/file.jpg",
+            DestinationPath = "/downloads/file.jpg",
+            Domain = "example.com",
+            SourceType = "RawUrl",
+            SourceId = "import-1"
+        };
+    }
+
+    private sealed record MetricMeasurement<T>(
+        string Name,
+        T Value,
+        IReadOnlyDictionary<string, object?> Tags);
+}

--- a/Octans.Tests/Downloads/HttpDownloaderTests.cs
+++ b/Octans.Tests/Downloads/HttpDownloaderTests.cs
@@ -23,6 +23,7 @@ public class HttpDownloaderTests
     private readonly IDownloadHostCircuitRegistry _hostCircuitRegistry = Substitute.For<IDownloadHostCircuitRegistry>();
     private readonly MockFileSystem _fileSystem = new();
     private readonly FakeTimeProvider _timeProvider = new();
+    private readonly DownloadTelemetry _telemetry = new();
     private readonly HttpDownloader _sut;
     private readonly CancellationTokenSource _cts = new();
     private readonly TestHttpMessageHandler _messageHandler = new();
@@ -65,6 +66,7 @@ public class HttpDownloaderTests
             new DownloadStagingPaths(_fileSystem),
             _timeProvider,
             Options.Create(options ?? new DownloadManagerOptions()),
+            _telemetry,
             NullLogger<HttpDownloader>.Instance);
     }
 


### PR DESCRIPTION
## Summary

- Wires OpenTelemetry into the client app for ASP.NET Core and HttpClient traces/metrics, with OTLP export enabled only when configured.
- Adds Octans-owned download telemetry for queue depth, active downloads, outcomes, duration, bytes, retries, and circuit transitions.
- Adds structured download logs around host/source/outcome details while removing full URLs from download log scopes so credentials/cookies are not emitted by app-level logging.
- Adds metric listener tests for the new download metrics.

Closes #187.

## Validation

- `dotnet build Octans.slnx -m:1`
- `dotnet test Octans.slnx -m:1 --no-build`