### PR TITLE
[codex] Add layered download timeouts

### DIFF
--- a/Octans.Core/Http/DownloadServiceExtensions.cs
+++ b/Octans.Core/Http/DownloadServiceExtensions.cs
@@ -44,7 +44,17 @@ public static class DownloadServiceExtensions
         services.TryAddSingleton<IDownloadQueue, DatabaseDownloadQueue>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, DownloadBackgroundService>());
 
-        services.AddHttpClient("DownloadClient")
+        services.AddHttpClient("DownloadClient", client => client.Timeout = Timeout.InfiniteTimeSpan)
+            .ConfigurePrimaryHttpMessageHandler(provider =>
+            {
+                var downloadOptions = provider.GetRequiredService<IOptions<DownloadManagerOptions>>().Value;
+
+                return new SocketsHttpHandler
+                {
+                    ConnectTimeout = GetEnabledTimeout(downloadOptions.Timeouts.ConnectionTimeout) ??
+                                     Timeout.InfiniteTimeSpan
+                };
+            })
             .AddStandardResilienceHandler()
             .Configure(ConfigureDownloadResilience)
             .SelectPipelineBy(_ => request => request.RequestUri?.Host ?? "unknown-host");
@@ -58,11 +68,14 @@ public static class DownloadServiceExtensions
     {
         var downloadOptions = provider.GetRequiredService<IOptions<DownloadManagerOptions>>().Value;
         var breakerOptions = downloadOptions.HostCircuitBreaker;
+        var timeoutOptions = downloadOptions.Timeouts;
 
         resilienceOptions.Retry.MaxRetryAttempts = breakerOptions.MaxRetryAttempts;
         resilienceOptions.Retry.Delay = breakerOptions.RetryDelay;
         resilienceOptions.Retry.BackoffType = DelayBackoffType.Exponential;
         resilienceOptions.Retry.UseJitter = true;
+        resilienceOptions.TotalRequestTimeout.Timeout = timeoutOptions.OverallTimeout;
+        resilienceOptions.AttemptTimeout.Timeout = timeoutOptions.ResponseHeaderTimeout;
 
         var circuitRegistry = provider.GetRequiredService<IDownloadHostCircuitRegistry>();
         var telemetry = provider.GetRequiredService<DownloadTelemetry>();
@@ -77,7 +90,9 @@ public static class DownloadServiceExtensions
 
         resilienceOptions.CircuitBreaker.FailureRatio = breakerOptions.FailureRatio;
         resilienceOptions.CircuitBreaker.MinimumThroughput = breakerOptions.MinimumThroughput;
-        resilienceOptions.CircuitBreaker.SamplingDuration = breakerOptions.SamplingDuration;
+        resilienceOptions.CircuitBreaker.SamplingDuration = Max(
+            breakerOptions.SamplingDuration,
+            Double(timeoutOptions.ResponseHeaderTimeout));
         resilienceOptions.CircuitBreaker.BreakDuration = breakerOptions.BreakDuration;
         resilienceOptions.CircuitBreaker.OnOpened = args =>
         {
@@ -99,6 +114,25 @@ public static class DownloadServiceExtensions
 
             return default;
         };
+    }
+
+    private static TimeSpan? GetEnabledTimeout(TimeSpan timeout)
+    {
+        return timeout > TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan
+            ? timeout
+            : null;
+    }
+
+    private static TimeSpan Max(TimeSpan left, TimeSpan right)
+    {
+        return left >= right ? left : right;
+    }
+
+    private static TimeSpan Double(TimeSpan value)
+    {
+        return value >= TimeSpan.FromTicks(TimeSpan.MaxValue.Ticks / 2)
+            ? TimeSpan.MaxValue
+            : TimeSpan.FromTicks(value.Ticks * 2);
     }
 
     /// <summary>

--- a/Octans.Core/Http/HttpDownloader.cs
+++ b/Octans.Core/Http/HttpDownloader.cs
@@ -8,6 +8,7 @@ using Octans.Core.Http.Bandwidth;
 using Octans.Core.Http.Models;
 using Octans.Data.Models;
 using Polly.CircuitBreaker;
+using Polly.Timeout;
 
 namespace Octans.Core.Http;
 
@@ -52,15 +53,36 @@ public class HttpDownloader(
         var attempt = new DownloadAttempt(download.Domain, timeProvider.GetTimestamp());
 
         // Create a combined token for this specific download
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(globalCancellation, downloadToken);
+        using var overallTimeout = DownloadTimeoutScope.Start(timeProvider, options.Value.Timeouts.OverallTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            globalCancellation,
+            downloadToken,
+            overallTimeout.Token);
         var combinedToken = linkedCts.Token;
 
         try
         {
-            await ProcessCore(download, downloadId, attempt, activity, combinedToken);
+            await ProcessCore(download, downloadId, attempt, activity, overallTimeout, combinedToken);
+        }
+        catch (DownloadTimeoutException ex)
+        {
+            RecordFailure(download, attempt, DownloadFailureCategory.Timeout, DownloadTerminalOutcome.Failed, ex);
+            await lifecycle.MarkFailedAsync(
+                downloadId,
+                ex.Message,
+                DownloadFailureCategory.Timeout);
+        }
+        catch (TimeoutRejectedException ex)
+        {
+            var message = $"Download timed out while waiting for the response headers after {options.Value.Timeouts.ResponseHeaderTimeout}.";
+            RecordFailure(download, attempt, DownloadFailureCategory.Timeout, DownloadTerminalOutcome.Failed, ex);
+            await lifecycle.MarkFailedAsync(
+                downloadId,
+                message,
+                DownloadFailureCategory.Timeout);
         }
         catch (OperationCanceledException)
-            when (combinedToken.IsCancellationRequested && !globalCancellation.IsCancellationRequested)
+            when (downloadToken.IsCancellationRequested && !globalCancellation.IsCancellationRequested)
         {
             var duration = attempt.GetElapsed(timeProvider);
             telemetry.RecordDownloadCanceled(download, duration);
@@ -70,6 +92,25 @@ public class HttpDownloader(
                 duration.TotalMilliseconds,
                 attempt.BytesTransferred);
             await lifecycle.MarkCanceledAsync(downloadId);
+        }
+        catch (OperationCanceledException ex)
+            when (overallTimeout.TimedOut && !globalCancellation.IsCancellationRequested)
+        {
+            var timeoutException = DownloadTimeoutException.Overall(options.Value.Timeouts.OverallTimeout, ex);
+            RecordFailure(download, attempt, DownloadFailureCategory.Timeout, DownloadTerminalOutcome.Failed, timeoutException);
+            await lifecycle.MarkFailedAsync(
+                downloadId,
+                timeoutException.Message,
+                DownloadFailureCategory.Timeout);
+        }
+        catch (OperationCanceledException ex) when (!globalCancellation.IsCancellationRequested)
+        {
+            var timeoutException = DownloadTimeoutException.Unknown(ex);
+            RecordFailure(download, attempt, DownloadFailureCategory.Timeout, DownloadTerminalOutcome.Failed, timeoutException);
+            await lifecycle.MarkFailedAsync(
+                downloadId,
+                timeoutException.Message,
+                DownloadFailureCategory.Timeout);
         }
         catch (HttpRequestException ex) when (ex.StatusCode is { } statusCode)
         {
@@ -189,6 +230,7 @@ public class HttpDownloader(
         Guid downloadId,
         DownloadAttempt attempt,
         Activity? activity,
+        DownloadTimeoutScope overallTimeout,
         CancellationToken combinedToken)
     {
         var started = await lifecycle.MarkInProgressAsync(downloadId);
@@ -213,15 +255,12 @@ public class HttpDownloader(
             logger.LogDebug("Prepared staging path {StagingPath}", stagingPath);
 
             using var httpClient = httpClientFactory.CreateClient("DownloadClient");
-            httpClient.Timeout = TimeSpan.FromHours(2); // Long timeout for large files
+            httpClient.Timeout = Timeout.InfiniteTimeSpan;
 
             using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(download.Url));
             requestHeaderProvider.ApplyHeaders(request);
 
-            using var response = await httpClient.SendAsync(
-                request,
-                HttpCompletionOption.ResponseHeadersRead,
-                combinedToken);
+            using var response = await SendWithHeaderTimeout(httpClient, request, combinedToken);
 
             attempt.CaptureResponse(response);
 
@@ -283,6 +322,7 @@ public class HttpDownloader(
                 response,
                 attempt,
                 maxDownloadSizeBytes,
+                overallTimeout,
                 combinedToken);
             if (totalBytes >= 0 && bytesDownloaded != totalBytes)
             {
@@ -346,6 +386,7 @@ public class HttpDownloader(
         HttpResponseMessage response,
         DownloadAttempt attempt,
         long? maxDownloadSizeBytes,
+        DownloadTimeoutScope overallTimeout,
         CancellationToken combinedToken)
     {
         await using var contentStream = await response.Content.ReadAsStreamAsync(combinedToken);
@@ -360,7 +401,7 @@ public class HttpDownloader(
         var lastReportBytes = 0L;
 
         int bytesRead;
-        while ((bytesRead = await contentStream.ReadAsync(buffer, combinedToken)) > 0)
+        while ((bytesRead = await ReadWithIdleTimeout(contentStream, buffer, overallTimeout, combinedToken)) > 0)
         {
             if (maxDownloadSizeBytes is { } maxBytes && bytesDownloaded > maxBytes - bytesRead)
             {
@@ -408,6 +449,50 @@ public class HttpDownloader(
         }
 
         return (bytesDownloaded, startTime);
+    }
+
+    private async Task<HttpResponseMessage> SendWithHeaderTimeout(
+        HttpClient httpClient,
+        HttpRequestMessage request,
+        CancellationToken combinedToken)
+    {
+        using var headerTimeout = DownloadTimeoutScope.Start(timeProvider, options.Value.Timeouts.ResponseHeaderTimeout);
+        using var sendCts = CancellationTokenSource.CreateLinkedTokenSource(combinedToken, headerTimeout.Token);
+
+        try
+        {
+            return await httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                sendCts.Token);
+        }
+        catch (OperationCanceledException ex) when (headerTimeout.TimedOut && !combinedToken.IsCancellationRequested)
+        {
+            throw DownloadTimeoutException.ResponseHeaders(options.Value.Timeouts.ResponseHeaderTimeout, ex);
+        }
+    }
+
+    private async Task<int> ReadWithIdleTimeout(
+        Stream contentStream,
+        byte[] buffer,
+        DownloadTimeoutScope overallTimeout,
+        CancellationToken combinedToken)
+    {
+        using var idleTimeout = DownloadTimeoutScope.Start(timeProvider, options.Value.Timeouts.IdleTimeout);
+        using var readCts = CancellationTokenSource.CreateLinkedTokenSource(combinedToken, idleTimeout.Token);
+
+        try
+        {
+            return await contentStream.ReadAsync(buffer, readCts.Token);
+        }
+        catch (OperationCanceledException ex) when (idleTimeout.TimedOut && !combinedToken.IsCancellationRequested)
+        {
+            throw DownloadTimeoutException.Idle(options.Value.Timeouts.IdleTimeout, ex);
+        }
+        catch (OperationCanceledException ex) when (overallTimeout.TimedOut)
+        {
+            throw DownloadTimeoutException.Overall(options.Value.Timeouts.OverallTimeout, ex);
+        }
     }
 
 
@@ -616,5 +701,86 @@ public class HttpDownloader(
             HttpStatusCode = (int)response.StatusCode;
             ResponseContentType = response.Content.Headers.ContentType?.ToString();
         }
+    }
+
+    private sealed class DownloadTimeoutScope : IDisposable
+    {
+        private readonly CancellationTokenSource? _cts;
+        private readonly ITimer? _timer;
+        private int _timedOut;
+
+        private DownloadTimeoutScope(TimeProvider timeProvider, TimeSpan timeout)
+        {
+            if (!IsEnabled(timeout))
+            {
+                return;
+            }
+
+            _cts = new();
+            _timer = timeProvider.CreateTimer(
+                static state => ((DownloadTimeoutScope)state!).CancelForTimeout(),
+                this,
+                timeout,
+                Timeout.InfiniteTimeSpan);
+        }
+
+        public CancellationToken Token => _cts?.Token ?? CancellationToken.None;
+        public bool TimedOut => Volatile.Read(ref _timedOut) == 1;
+
+        public static DownloadTimeoutScope Start(TimeProvider timeProvider, TimeSpan timeout) => new(timeProvider, timeout);
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+            _cts?.Dispose();
+        }
+
+        private void CancelForTimeout()
+        {
+            if (Interlocked.Exchange(ref _timedOut, 1) == 1)
+            {
+                return;
+            }
+
+            try
+            {
+                _cts?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        private static bool IsEnabled(TimeSpan timeout)
+        {
+            return timeout > TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan;
+        }
+    }
+
+    private sealed class DownloadTimeoutException : TimeoutException
+    {
+        public DownloadTimeoutException()
+        {
+        }
+
+        public DownloadTimeoutException(string message) : base(message)
+        {
+        }
+
+        public DownloadTimeoutException(string message, Exception? innerException) : base(message, innerException)
+        {
+        }
+
+        public static DownloadTimeoutException ResponseHeaders(TimeSpan timeout, Exception innerException) =>
+            new($"Download timed out while waiting for the response headers after {timeout}.", innerException);
+
+        public static DownloadTimeoutException Idle(TimeSpan timeout, Exception innerException) =>
+            new($"Download stalled: no bytes were received for {timeout}.", innerException);
+
+        public static DownloadTimeoutException Overall(TimeSpan timeout, Exception innerException) =>
+            new($"Download exceeded the overall timeout of {timeout}.", innerException);
+
+        public static DownloadTimeoutException Unknown(Exception innerException) =>
+            new("Download timed out before the HTTP transfer completed.", innerException);
     }
 }

--- a/Octans.Core/Http/Models/DownloadManagerOptions.cs
+++ b/Octans.Core/Http/Models/DownloadManagerOptions.cs
@@ -13,6 +13,18 @@ public class DownloadManagerOptions
     public DownloadContentTypeValidationOptions ContentTypeValidation { get; set; } = new();
     public DownloadHostCircuitBreakerOptions HostCircuitBreaker { get; set; } = new();
     public DownloadRequestHeaderOptions RequestHeaders { get; set; } = new();
+    public DownloadTimeoutOptions Timeouts { get; set; } = new();
+}
+
+/// <summary>
+/// Timeout settings for distinct phases of a durable HTTP download.
+/// </summary>
+public class DownloadTimeoutOptions
+{
+    public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan ResponseHeaderTimeout { get; set; } = TimeSpan.FromSeconds(10);
+    public TimeSpan OverallTimeout { get; set; } = TimeSpan.FromHours(2);
+    public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(1);
 }
 
 /// <summary>

--- a/Octans.Core/Http/README.md
+++ b/Octans.Core/Http/README.md
@@ -54,6 +54,10 @@ builder.Services.AddDownloadManager(options =>
     options.SizeLimits.MaxBytes = 10L * 1024 * 1024 * 1024;
     options.ContentTypeValidation.AllowMissingContentType = true;
     options.ContentTypeValidation.AllowGenericContentType = true;
+    options.Timeouts.ConnectionTimeout = TimeSpan.FromSeconds(30);
+    options.Timeouts.ResponseHeaderTimeout = TimeSpan.FromSeconds(10);
+    options.Timeouts.OverallTimeout = TimeSpan.FromHours(2);
+    options.Timeouts.IdleTimeout = TimeSpan.FromMinutes(1);
 });
 ```
 
@@ -74,6 +78,12 @@ Downloads enforce `DownloadManagerOptions.SizeLimits.MaxBytes` before streaming
 known oversized responses and while streaming unknown or misreported response
 bodies. Domain and source-type entries can override the global cap for specific
 hosts or callers.
+
+Downloads use layered timeouts instead of one coarse `HttpClient.Timeout`.
+`ConnectionTimeout` is applied to connection establishment, `ResponseHeaderTimeout`
+covers the request through response headers, `OverallTimeout` covers the whole
+job, and `IdleTimeout` fails a body transfer only when no bytes arrive within
+the configured window.
 
 ## Components
 

--- a/Octans.Data/Models/DownloadFailureCategory.cs
+++ b/Octans.Data/Models/DownloadFailureCategory.cs
@@ -8,5 +8,6 @@ public enum DownloadFailureCategory
     Validation,
     Filesystem,
     SizeLimit,
-    Authentication
+    Authentication,
+    Timeout
 }

--- a/Octans.Tests/Downloads/HttpDownloaderTests.cs
+++ b/Octans.Tests/Downloads/HttpDownloaderTests.cs
@@ -219,9 +219,121 @@ public class HttpDownloaderTests
 
         await _lifecycle.Received(1).MarkInProgressAsync(downloadId);
         await _lifecycle.Received(1).MarkCanceledAsync(downloadId);
+        await _lifecycle.DidNotReceive().MarkFailedAsync(
+            downloadId,
+            Arg.Any<string>(),
+            DownloadFailureCategory.Timeout);
         await _lifecycle.DidNotReceive().MarkCompletedAsync(downloadId);
         Assert.False(_fileSystem.File.Exists(destinationPath));
         Assert.False(_fileSystem.File.Exists(GetStagingPath(downloadId, destinationPath)));
+    }
+
+    [Fact]
+    public async Task ProcessDownloadAsync_WhenResponseHeadersStall_MarksDownloadFailedWithTimeout()
+    {
+        var sut = CreateDownloader(new()
+        {
+            Timeouts = new()
+            {
+                ResponseHeaderTimeout = TimeSpan.FromSeconds(5),
+                OverallTimeout = TimeSpan.FromMinutes(5),
+                IdleTimeout = TimeSpan.FromMinutes(5)
+            }
+        });
+        var downloadId = Guid.NewGuid();
+        var destinationPath = "/downloads/test.txt";
+        var download = CreateDownload(downloadId, destinationPath);
+        _messageHandler.WaitForCancellation = true;
+
+        var downloadTask = sut.ProcessDownloadAsync(download, _cts.Token);
+
+        await _messageHandler.RequestStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        _timeProvider.Advance(TimeSpan.FromSeconds(5));
+        await downloadTask;
+
+        await _lifecycle.Received(1).MarkFailedAsync(
+            downloadId,
+            Arg.Is<string>(s => s.Contains("response headers") && s.Contains("00:00:05")),
+            DownloadFailureCategory.Timeout);
+        await _lifecycle.DidNotReceive().MarkCanceledAsync(downloadId);
+        await _lifecycle.DidNotReceive().MarkCompletedAsync(downloadId);
+        Assert.False(_fileSystem.File.Exists(destinationPath));
+        Assert.False(_fileSystem.File.Exists(GetStagingPath(downloadId, destinationPath)));
+    }
+
+    [Fact]
+    public async Task ProcessDownloadAsync_WhenBodyStalls_MarksDownloadFailedWithTimeout()
+    {
+        var sut = CreateDownloader(new()
+        {
+            Timeouts = new()
+            {
+                ResponseHeaderTimeout = TimeSpan.FromMinutes(5),
+                OverallTimeout = TimeSpan.FromMinutes(5),
+                IdleTimeout = TimeSpan.FromSeconds(5)
+            }
+        });
+        var downloadId = Guid.NewGuid();
+        var destinationPath = "/downloads/test.txt";
+        var download = CreateDownload(downloadId, destinationPath);
+        var content = new PausingReadContent("hello");
+        _messageHandler.ResponseToReturn = new(HttpStatusCode.OK)
+        {
+            Content = content
+        };
+
+        var downloadTask = sut.ProcessDownloadAsync(download, _cts.Token);
+
+        await content.SecondReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        _timeProvider.Advance(TimeSpan.FromSeconds(5));
+        await downloadTask;
+
+        await _lifecycle.Received(1).MarkFailedAsync(
+            downloadId,
+            Arg.Is<string>(s => s.Contains("stalled") && s.Contains("00:00:05")),
+            DownloadFailureCategory.Timeout);
+        await _lifecycle.DidNotReceive().MarkCanceledAsync(downloadId);
+        await _lifecycle.DidNotReceive().MarkCompletedAsync(downloadId);
+        Assert.False(_fileSystem.File.Exists(destinationPath));
+        Assert.False(_fileSystem.File.Exists(GetStagingPath(downloadId, destinationPath)));
+    }
+
+    [Fact]
+    public async Task ProcessDownloadAsync_WhenBodyKeepsProgressingWithinIdleTimeout_CompletesDownload()
+    {
+        var sut = CreateDownloader(new()
+        {
+            Timeouts = new()
+            {
+                ResponseHeaderTimeout = TimeSpan.FromMinutes(5),
+                OverallTimeout = TimeSpan.FromMinutes(5),
+                IdleTimeout = TimeSpan.FromSeconds(5)
+            }
+        });
+        var downloadId = Guid.NewGuid();
+        var destinationPath = "/downloads/test.txt";
+        var download = CreateDownload(downloadId, destinationPath);
+        var content = new PausingReadContent("hello");
+        _messageHandler.ResponseToReturn = new(HttpStatusCode.OK)
+        {
+            Content = content
+        };
+
+        var downloadTask = sut.ProcessDownloadAsync(download, _cts.Token);
+
+        await content.SecondReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        _timeProvider.Advance(TimeSpan.FromSeconds(4));
+        content.ReleaseSecondRead();
+        await downloadTask;
+
+        Assert.Equal("hello", await _fileSystem.File.ReadAllTextAsync(destinationPath));
+        await _lifecycle.Received(1).MarkCompletedAsync(
+            downloadId,
+            Arg.Is<DownloadTerminalUpdate>(update => update.Outcome == DownloadTerminalOutcome.Completed));
+        await _lifecycle.DidNotReceive().MarkFailedAsync(
+            downloadId,
+            Arg.Any<string>(),
+            DownloadFailureCategory.Timeout);
     }
 
     [Fact]

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -110,8 +110,9 @@ What exists now:
 - The named `DownloadClient` uses `Microsoft.Extensions.Http.Resilience` with exponential retry, jitter, and per-host circuit-breaker pipelines.
 - Host circuits feed back into queue selection so an unhealthy host does not block healthy hosts.
 - Request headers support default User-Agent, per-domain overrides, auth/cookie headers, required-header checks, wildcard domain matching, and a request fingerprint.
+- Download timeouts are layered: connection establishment, response headers, overall job duration, and idle/stall body reads are configured separately, with timeout failures distinct from user cancellation.
 - There is a real integration harness for the download manager using actual DI, queue/state/background/downloader services with the bottom HTTP edge faked.
-- Tests cover queue ordering/restoration, state transitions, pause/cancel/retry, terminal notifications, staging cleanup, HTTP failures, transient retry, host circuits, per-domain concurrency, bandwidth pacing, disk-space checks, content-type validation, size limits, hash validation, request headers, and credential failures.
+- Tests cover queue ordering/restoration, state transitions, pause/cancel/retry, terminal notifications, staging cleanup, HTTP failures, transient retry, host circuits, per-domain concurrency, bandwidth pacing, disk-space checks, content-type validation, size limits, hash validation, request headers, credential failures, response-header timeout, idle/stall timeout, and cancellation/timeout distinction.
 
 Known GitHub backlog:
 
@@ -119,7 +120,6 @@ Known GitHub backlog:
 - #183: make per-host connection pooling and concurrency limits explicit below the worker-level cap.
 - #185: support conditional re-fetching with ETag/Last-Modified and `304 Not Modified`.
 - #187: add structured metrics, not just structured logs.
-- #188: add layered timeouts, especially response-header and idle/stall timeouts.
 - #193: tracker for the hardening work; most child issues are closed, with the above still open.
 - #202: route `RawUrl` imports through the download-job subsystem instead of `SimpleImporter.GetByteArrayAsync`.
 - #203: move downloader discovery fetches behind a shared HTTP document/body-fetch abstraction.
@@ -131,7 +131,6 @@ Important current limitations:
 - The durable queue does not deduplicate identical in-flight requests yet. `RequestFingerprint` exists, but there is no coalescing model or multi-subscriber completion model.
 - Per-domain concurrency is enforced by the background worker, not by configured lower-level connection pooling or redirect-aware host accounting.
 - Conditional requests are not implemented. Response ETag/Last-Modified are persisted, but there is no first-class re-fetch request path or `NotModified` handling.
-- Timeout policy is still coarse. `HttpDownloader` sets a long overall `HttpClient.Timeout`; there are not distinct connection, header, overall, and idle/stall timeouts.
 - Redirect policy is mostly whatever the HTTP client/resilience stack does by default. There is no explicit redirect cap/loop/cross-domain policy in the download subsystem.
 - Observability is mostly logs and status rows. There is no metrics surface for per-host queue depth, active downloads, latency, bytes, retry counts, failure rates, or circuit state.
 - Feature-level continuation is still loose. A caller can poll results or provide an `IDownloadCompletionNotifier`, but there is not yet a polished bridge for workflows like "download then import this completed artifact".


### PR DESCRIPTION
## Summary

Adds configurable layered timeout policy for the durable HTTP downloader:

- connection timeout on the named `DownloadClient` handler
- response-header timeout for the `ResponseHeadersRead` request phase
- overall job timeout using the injected `TimeProvider`
- idle/stall timeout based on time since the last body bytes were received

Timeouts now persist as `DownloadFailureCategory.Timeout` and remain distinct from user pause/cancel paths.

Closes #188.

## Validation

- `dotnet test Octans.slnx --filter FullyQualifiedName~Octans.Tests.Downloads.HttpDownloaderTests -m:1`
- `dotnet build Octans.slnx -m:1`
- `dotnet test Octans.slnx -m:1 --no-build`