### PR TITLE
[codex] Bound downloader resolution resources

### DIFF
--- a/Octans.Client/ServiceCollectionExtensions.cs
+++ b/Octans.Client/ServiceCollectionExtensions.cs
@@ -110,6 +110,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<FilesystemWriter>();
         services.AddScoped<ImportFilterService>();
         services.AddSingleton<ThumbnailCreator>();
+        services.AddOptions<DownloaderResolverOptions>();
         services.AddScoped<DownloaderFactory>();
         services.AddScoped<DownloaderService>();
 

--- a/Octans.Core/Downloaders/Downloader.cs
+++ b/Octans.Core/Downloaders/Downloader.cs
@@ -65,9 +65,9 @@ public sealed class Downloader : IDisposable
         string operation) =>
         new(lua, lua.GetFunction(functionName), operation);
 
-    public bool MatchesUrl(Uri url)
+    public bool MatchesUrl(Uri url, CancellationToken cancellationToken = default)
     {
-        var res = _matchUrl.Call(url.AbsoluteUri).FirstOrDefault();
+        var res = _matchUrl.Call(cancellationToken, url.AbsoluteUri).FirstOrDefault();
 
         return res is bool b
             ? b
@@ -75,9 +75,9 @@ public sealed class Downloader : IDisposable
     }
 
     // function classify_url(url) -> "Post" || "Gallery"
-    public DownloaderUrlClassification ClassifyUrl(Uri url)
+    public DownloaderUrlClassification ClassifyUrl(Uri url, CancellationToken cancellationToken = default)
     {
-        var raw = _classifyUrl.Call(url.AbsoluteUri).FirstOrDefault();
+        var raw = _classifyUrl.Call(cancellationToken, url.AbsoluteUri).FirstOrDefault();
 
         if (raw is not string s)
         {
@@ -93,33 +93,33 @@ public sealed class Downloader : IDisposable
     }
 
     // function parse_html(html_content) -> string[]
-    public List<string> ParseHtml(string htmlContent)
+    public List<string> ParseHtml(string htmlContent, CancellationToken cancellationToken = default)
     {
-        var result = _parseHtml.Call(htmlContent).FirstOrDefault();
+        var result = _parseHtml.Call(cancellationToken, htmlContent).FirstOrDefault();
 
         return ReadStringTable(result, "parse_html", MaxReturnedUrls);
     }
 
-    public string GenerateGalleryUrl(string input, int page)
+    public string GenerateGalleryUrl(string input, int page, CancellationToken cancellationToken = default)
     {
         if (_generateGalleryUrl is null)
         {
             throw new DownloaderContractException("No GUG provided for downloader.");
         }
 
-        var result = _generateGalleryUrl.Call(input, page).FirstOrDefault() as string;
+        var result = _generateGalleryUrl.Call(cancellationToken, input, page).FirstOrDefault() as string;
 
         return ValidateNonEmptyString(result, "generate_url return value");
     }
 
-    public string ProcessApiQuery(string query)
+    public string ProcessApiQuery(string query, CancellationToken cancellationToken = default)
     {
         if (_processApiQuery is null)
         {
             throw new InvalidOperationException("No API component provided for downloader");
         }
 
-        if (_processApiQuery.Call(query).FirstOrDefault() is not NLua.LuaTable result)
+        if (_processApiQuery.Call(cancellationToken, query).FirstOrDefault() is not NLua.LuaTable result)
         {
             throw new DownloaderContractException("process_query must return a table.");
         }
@@ -196,6 +196,7 @@ public sealed class Downloader : IDisposable
         NLua.LuaFunction Function,
         string Operation)
     {
-        public object[] Call(params object[] args) => Context.Call(Function, Operation, args);
+        public object[] Call(CancellationToken cancellationToken = default, params object[] args) =>
+            Context.Call(Function, Operation, cancellationToken, args);
     }
 }

--- a/Octans.Core/Downloaders/DownloaderLuaContext.cs
+++ b/Octans.Core/Downloaders/DownloaderLuaContext.cs
@@ -30,12 +30,18 @@ internal sealed class DownloaderLuaContext : IDisposable
     private readonly object _executionLock = new();
     private int _remainingHookCalls;
     private string _currentOperation = "Lua script";
+    private CancellationToken _currentCancellationToken = CancellationToken.None;
 
     private DownloaderLuaContext(Lua lua)
     {
         _lua = lua;
         _instructionHook = (_, _) =>
         {
+            if (_currentCancellationToken.IsCancellationRequested)
+            {
+                _lua.State.Error("Downloader {0} was canceled.", _currentOperation);
+            }
+
             _remainingHookCalls--;
             if (_remainingHookCalls > 0)
             {
@@ -59,11 +65,15 @@ internal sealed class DownloaderLuaContext : IDisposable
 
     public LuaTable? GetTable(string tableName) => _lua.GetTable(tableName);
 
-    public object[] DoString(string script, string operation) =>
-        RunWithBudget(operation, () => _lua.DoString(script, operation));
+    public object[] DoString(string script, string operation, CancellationToken cancellationToken = default) =>
+        RunWithBudget(operation, () => _lua.DoString(script, operation), cancellationToken);
 
-    public object[] Call(LuaFunction function, string operation, params object[] args) =>
-        RunWithBudget(operation, () => function.Call(args));
+    public object[] Call(
+        LuaFunction function,
+        string operation,
+        CancellationToken cancellationToken = default,
+        params object[] args) =>
+        RunWithBudget(operation, () => function.Call(args), cancellationToken);
 
     public void Dispose()
     {
@@ -73,20 +83,28 @@ internal sealed class DownloaderLuaContext : IDisposable
         }
     }
 
-    private T RunWithBudget<T>(string operation, Func<T> action)
+    private T RunWithBudget<T>(string operation, Func<T> action, CancellationToken cancellationToken)
     {
         // Downloader instances cache Lua contexts, so every call into an NLua state is serialized here.
         lock (_executionLock)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             _currentOperation = operation;
+            _currentCancellationToken = cancellationToken;
             _remainingHookCalls = Math.Max(1, MaxInstructionCount / InstructionHookInterval);
             _lua.State.SetHook(_instructionHook, LuaHookMask.Count, InstructionHookInterval);
 
             try
             {
-                return action();
+                var result = action();
+                cancellationToken.ThrowIfCancellationRequested();
+                return result;
             }
-            catch (Exception ex) when (ex is not DownloaderContractException)
+            catch (Exception ex) when (cancellationToken.IsCancellationRequested && ex is not OperationCanceledException)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+            catch (Exception ex) when (ex is not DownloaderContractException and not OperationCanceledException)
             {
                 throw new DownloaderContractException($"Downloader {operation} failed.", ex);
             }
@@ -94,6 +112,7 @@ internal sealed class DownloaderLuaContext : IDisposable
             {
                 _lua.State.SetHook(null, LuaHookMask.Disabled, 0);
                 _currentOperation = "Lua script";
+                _currentCancellationToken = CancellationToken.None;
             }
         }
     }

--- a/Octans.Core/Downloaders/DownloaderResolverOptions.cs
+++ b/Octans.Core/Downloaders/DownloaderResolverOptions.cs
@@ -1,0 +1,7 @@
+namespace Octans.Core.Downloaders;
+
+public class DownloaderResolverOptions
+{
+    public TimeSpan OperationTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    public long MaxResponseBytes { get; set; } = 5L * 1024 * 1024;
+}

--- a/Octans.Core/Downloaders/DownloaderService.cs
+++ b/Octans.Core/Downloaders/DownloaderService.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Octans.Core.Http;
 
 namespace Octans.Core.Downloaders;
@@ -7,10 +9,14 @@ public class DownloaderService(
     IHttpClientFactory clientFactory,
     DownloaderFactory downloaderFactory,
     IDownloadRequestHeaderProvider requestHeaderProvider,
+    IOptions<DownloaderResolverOptions> options,
     ILogger<DownloaderService> logger)
 {
-    public async Task<IReadOnlyList<Uri>> ResolveAsync(Uri uri)
+    public async Task<IReadOnlyList<Uri>> ResolveAsync(Uri uri, CancellationToken cancellationToken = default)
     {
+        using var operationTimeout = CreateOperationTimeout(cancellationToken);
+        var resolverToken = operationTimeout.Token;
+
         var downloaders = await downloaderFactory.GetDownloaders();
 
 #pragma warning disable CA2000
@@ -21,7 +27,9 @@ public class DownloaderService(
 
         foreach (var downloader in downloaders)
         {
-            if (!TryRun(downloader, "match_url", () => downloader.MatchesUrl(uri)))
+            resolverToken.ThrowIfCancellationRequested();
+
+            if (!TryRun(downloader, "match_url", () => downloader.MatchesUrl(uri, resolverToken)))
             {
                 continue;
             }
@@ -29,33 +37,49 @@ public class DownloaderService(
             var classification = TryRun<DownloaderUrlClassification?>(
                 downloader,
                 "classify_url",
-                () => downloader.ClassifyUrl(uri));
+                () => downloader.ClassifyUrl(uri, resolverToken));
             if (classification is null or DownloaderUrlClassification.Unknown)
             {
                 continue;
             }
 
-            var content = raw ??= await GetStringAsync(client, uri);
+            if (raw is null)
+            {
+                raw = await TryRunAsync(downloader, "fetch_html", () => GetStringAsync(client, uri, resolverToken));
+                if (raw is null)
+                {
+                    return [];
+                }
+            }
+
+            var content = raw;
             if (classification is DownloaderUrlClassification.Gallery)
             {
                 var galleryUrl = TryRun(
                     downloader,
                     "generate_url",
-                    () => CreateHttpUri(downloader.GenerateGalleryUrl(uri.AbsoluteUri, 0), "generate_url"));
+                    () => CreateHttpUri(downloader.GenerateGalleryUrl(uri.AbsoluteUri, 0, resolverToken), "generate_url"));
 
                 if (galleryUrl is null)
                 {
                     continue;
                 }
 
-                content = await GetStringAsync(client, galleryUrl);
+                content = await TryRunAsync(
+                    downloader,
+                    "fetch_gallery_html",
+                    () => GetStringAsync(client, galleryUrl, resolverToken));
+                if (content is null)
+                {
+                    continue;
+                }
             }
 
             var urls = TryRun(
                 downloader,
                 "parse_html",
                 () => downloader
-                    .ParseHtml(content)
+                    .ParseHtml(content, resolverToken)
                     .Select(u => CreateHttpUri(u, "parse_html"))
                     .ToList());
 
@@ -68,14 +92,86 @@ public class DownloaderService(
         return [];
     }
 
-    private async Task<string> GetStringAsync(HttpClient client, Uri uri)
+    private async Task<string> GetStringAsync(HttpClient client, Uri uri, CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, uri);
         requestHeaderProvider.ApplyHeaders(request);
 
-        using var response = await client.SendAsync(request);
+        using var response = await client.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync();
+        return await ReadBoundedStringAsync(response, uri, cancellationToken);
+    }
+
+    private async Task<string> ReadBoundedStringAsync(
+        HttpResponseMessage response,
+        Uri uri,
+        CancellationToken cancellationToken)
+    {
+        var maxResponseBytes = options.Value.MaxResponseBytes;
+        var reportedBytes = response.Content.Headers.ContentLength;
+        if (maxResponseBytes > 0 && reportedBytes > maxResponseBytes)
+        {
+            throw new DownloaderContractException(
+                $"Downloader response from {uri.Host} reported {reportedBytes} bytes, exceeding the configured {maxResponseBytes} byte limit.");
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var buffer = new MemoryStream();
+        var bytes = new byte[81920];
+        long totalBytes = 0;
+
+        while (true)
+        {
+            var bytesRead = await stream.ReadAsync(bytes, cancellationToken);
+            if (bytesRead <= 0)
+            {
+                break;
+            }
+
+            if (maxResponseBytes > 0 && totalBytes > maxResponseBytes - bytesRead)
+            {
+                throw new DownloaderContractException(
+                    $"Downloader response from {uri.Host} exceeded the configured {maxResponseBytes} byte limit.");
+            }
+
+            await buffer.WriteAsync(bytes.AsMemory(0, bytesRead), cancellationToken);
+            totalBytes += bytesRead;
+        }
+
+        return GetResponseEncoding(response).GetString(buffer.ToArray());
+    }
+
+    private static Encoding GetResponseEncoding(HttpResponseMessage response)
+    {
+        var charset = response.Content.Headers.ContentType?.CharSet;
+        if (string.IsNullOrWhiteSpace(charset))
+        {
+            return Encoding.UTF8;
+        }
+
+        try
+        {
+            return Encoding.GetEncoding(charset);
+        }
+        catch (ArgumentException)
+        {
+            return Encoding.UTF8;
+        }
+    }
+
+    private CancellationTokenSource CreateOperationTimeout(CancellationToken cancellationToken)
+    {
+        var timeout = options.Value.OperationTimeout;
+        var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (timeout > TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+        {
+            source.CancelAfter(timeout);
+        }
+
+        return source;
     }
 
     private static Uri CreateHttpUri(string value, string source)
@@ -103,9 +199,28 @@ public class DownloaderService(
         {
             logger.LogWarning(
                 ex,
-                "Downloader {DownloaderName} failed during {DownloaderOperation}",
+                "Skipping downloader {DownloaderName} after failure during {DownloaderOperation}: {Message}",
                 GetDownloaderName(downloader),
-                operation);
+                operation,
+                ex.Message);
+            return default;
+        }
+    }
+
+    private async Task<T?> TryRunAsync<T>(Downloader downloader, string operation, Func<Task<T>> action)
+    {
+        try
+        {
+            return await action();
+        }
+        catch (DownloaderContractException ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Skipping downloader {DownloaderName} after failure during {DownloaderOperation}: {Message}",
+                GetDownloaderName(downloader),
+                operation,
+                ex.Message);
             return default;
         }
     }

--- a/Octans.Tests/Importing/DownloaderFactoryTests.cs
+++ b/Octans.Tests/Importing/DownloaderFactoryTests.cs
@@ -210,7 +210,7 @@ public class DownloaderFactoryTests
         clientFactory.CreateClient("DownloadClient").Returns(httpClient);
 
         var headerProvider = Substitute.For<IDownloadRequestHeaderProvider>();
-        var service = new DownloaderService(clientFactory, _sut, headerProvider, NullLogger<DownloaderService>.Instance);
+        var service = CreateService(clientFactory, headerProvider);
 
         var urls = await service.ResolveAsync(new("https://example.com/post/1"));
 
@@ -252,17 +252,72 @@ public class DownloaderFactoryTests
         clientFactory.CreateClient("DownloadClient").Returns(httpClient);
 
         var headerProvider = Substitute.For<IDownloadRequestHeaderProvider>();
-        var service = new DownloaderService(clientFactory, _sut, headerProvider, NullLogger<DownloaderService>.Instance);
+        var service = CreateService(clientFactory, headerProvider);
 
         var urls = await service.ResolveAsync(new("https://example.com/post/1"));
 
         urls.Should().Equal(new Uri("https://example.com/image.jpg"));
     }
 
+    [Fact]
+    public async Task ResolveAsync_ShouldRejectResponsesLargerThanConfiguredLimit()
+    {
+        var subdir = _downloaders.CreateSubdirectory("first");
+        AddFileToSubdir(subdir, "classifier", _classifier);
+        AddFileToSubdir(subdir, "parser", _parser);
+
+        var clientFactory = Substitute.For<IHttpClientFactory>();
+        using var httpClient = new HttpClient(new StaticHttpMessageHandler("too large"));
+        clientFactory.CreateClient("DownloadClient").Returns(httpClient);
+
+        var headerProvider = Substitute.For<IDownloadRequestHeaderProvider>();
+        var service = CreateService(clientFactory, headerProvider, new() { MaxResponseBytes = 4 });
+
+        var urls = await service.ResolveAsync(new("https://example.com/post/1"));
+
+        urls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldHonorCancellationTokenDuringFetch()
+    {
+        var subdir = _downloaders.CreateSubdirectory("first");
+        AddFileToSubdir(subdir, "classifier", _classifier);
+        AddFileToSubdir(subdir, "parser", _parser);
+
+        var handler = new CancellableHttpMessageHandler();
+        var clientFactory = Substitute.For<IHttpClientFactory>();
+        using var httpClient = new HttpClient(handler);
+        clientFactory.CreateClient("DownloadClient").Returns(httpClient);
+
+        var headerProvider = Substitute.For<IDownloadRequestHeaderProvider>();
+        var service = CreateService(clientFactory, headerProvider);
+        using var cts = new CancellationTokenSource();
+
+        var resolveTask = service.ResolveAsync(new("https://example.com/post/1"), cts.Token);
+        await handler.WaitUntilStarted();
+
+        await cts.CancelAsync();
+
+        var act = async () => await resolveTask;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     private void AddFileToSubdir(IDirectoryInfo dir, string filename, MockFileData data)
     {
         _fileSystem.AddFile(dir.FullName + $"/{filename}.lua", data);
     }
+
+    private DownloaderService CreateService(
+        IHttpClientFactory clientFactory,
+        IDownloadRequestHeaderProvider headerProvider,
+        DownloaderResolverOptions? resolverOptions = null) =>
+        new(
+            clientFactory,
+            _sut,
+            headerProvider,
+            Options.Create(resolverOptions ?? new DownloaderResolverOptions()),
+            NullLogger<DownloaderService>.Instance);
 
     private sealed class StaticHttpMessageHandler(string content) : HttpMessageHandler
     {
@@ -273,5 +328,25 @@ public class DownloaderFactoryTests
             {
                 Content = new StringContent(content)
             });
+    }
+
+    private sealed class CancellableHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitUntilStarted() => _started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _started.SetResult();
+            await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+
+            return new()
+            {
+                Content = new StringContent("<html></html>")
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary

- thread cancellation through downloader resolution and Lua downloader calls
- add a resolver operation timeout and max response size guard for downloader discovery HTML/API fetches
- stream discovery responses with `ResponseHeadersRead` instead of buffering unbounded content
- log skipped downloader failures with downloader name, operation, and bounded diagnostic message

Closes #201.

## Validation

- `dotnet build Octans.slnx -m:1`
- `dotnet test Octans.Tests/Octans.Tests.csproj -m:1 --no-build --filter DownloaderFactoryTests`
- `dotnet test Octans.slnx -m:1 --no-build`