### PR TITLE
[codex] Encapsulate core service implementations

### DIFF
--- a/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
+++ b/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
@@ -4,9 +4,9 @@ namespace Octans.Client.Components.Downloads;
 
 public class DownloadersViewmodel
 {
-    private readonly DownloaderFactory _factory;
+    private readonly IDownloaderFactory _factory;
 
-    public DownloadersViewmodel(DownloaderFactory factory)
+    public DownloadersViewmodel(IDownloaderFactory factory)
     {
         _factory = factory;
     }

--- a/Octans.Client/Components/Subscriptions/SubscriptionsViewmodel.cs
+++ b/Octans.Client/Components/Subscriptions/SubscriptionsViewmodel.cs
@@ -5,8 +5,8 @@ using Octans.Core.Subscriptions;
 namespace Octans.Client.Components.Subscriptions;
 
 public class SubscriptionsViewmodel(
-    SubscriptionService subscriptionService,
-    DownloaderFactory downloaderFactory,
+    ISubscriptionService subscriptionService,
+    IDownloaderFactory downloaderFactory,
     IDialogService dialogService)
 {
     public List<SubscriptionStatusDto> Subscriptions { get; private set; } = [];

--- a/Octans.Client/Endpoints.cs
+++ b/Octans.Client/Endpoints.cs
@@ -45,7 +45,7 @@ internal static class Endpoints
     private static void MapDownloaderEndpoints(WebApplication app)
     {
         app.MapGet("/downloaders",
-            async ([FromServices] DownloaderFactory ds) =>
+            async ([FromServices] IDownloaderFactory ds) =>
             {
                 var downloaders = await ds.GetDownloaders();
 
@@ -53,7 +53,7 @@ internal static class Endpoints
             });
 
         app.MapGet("/downloaders/{name}",
-            async (string name, [FromServices] DownloaderFactory ds) =>
+            async (string name, [FromServices] IDownloaderFactory ds) =>
             {
                 var downloaders = await ds.GetDownloaders();
 
@@ -79,14 +79,14 @@ internal static class Endpoints
 
         app
             .MapPost("/files/query",
-                ([FromBody] IEnumerable<string> queries, [FromServices] QueryService service) => service.Query(queries))
+                ([FromBody] IEnumerable<string> queries, [FromServices] IQueryService service) => service.Query(queries))
             .WithName("Search by Query")
             .WithDescription("Retrieve files found by a tag query search");
 
         app
             .MapPost("/files",
                 async ([FromBody] ImportRequest request,
-                    [FromServices] ImportJobService service,
+                    [FromServices] IImportJobService service,
                     CancellationToken token) =>
                 {
                     var created = await service.Create(ImportJobCreateRequestFromImportRequest(request), token);
@@ -112,7 +112,7 @@ internal static class Endpoints
         app
             .MapPost("/import-jobs",
                 async ([FromBody] ImportJobCreateRequest request,
-                    [FromServices] ImportJobService service,
+                    [FromServices] IImportJobService service,
                     CancellationToken token) =>
                 {
                     var created = await service.Create(request, token);
@@ -124,14 +124,14 @@ internal static class Endpoints
 
         app
             .MapGet("/import-jobs",
-                async ([FromServices] ImportJobService service, CancellationToken token) =>
+                async ([FromServices] IImportJobService service, CancellationToken token) =>
                     await service.GetJobs(token))
             .WithName("GetImportJobs")
             .WithDescription("Gets recent import jobs");
 
         app
             .MapGet("/import-jobs/{id:guid}",
-                async (Guid id, [FromServices] ImportJobService service, CancellationToken token) =>
+                async (Guid id, [FromServices] IImportJobService service, CancellationToken token) =>
                 {
                     var job = await service.GetJob(id, token);
 
@@ -142,7 +142,7 @@ internal static class Endpoints
 
         app
             .MapPost("/import-jobs/{id:guid}/pause",
-                async (Guid id, [FromServices] ImportJobService service, CancellationToken token) =>
+                async (Guid id, [FromServices] IImportJobService service, CancellationToken token) =>
                 {
                     var job = await service.PauseJob(id, token);
 
@@ -152,7 +152,7 @@ internal static class Endpoints
 
         app
             .MapPost("/import-jobs/{id:guid}/resume",
-                async (Guid id, [FromServices] ImportJobService service, CancellationToken token) =>
+                async (Guid id, [FromServices] IImportJobService service, CancellationToken token) =>
                 {
                     var job = await service.ResumeJob(id, token);
 
@@ -162,7 +162,7 @@ internal static class Endpoints
 
         app
             .MapPost("/import-jobs/{id:guid}/cancel",
-                async (Guid id, [FromServices] ImportJobService service, CancellationToken token) =>
+                async (Guid id, [FromServices] IImportJobService service, CancellationToken token) =>
                 {
                     var job = await service.CancelJob(id, token);
 

--- a/Octans.Client/Program.cs
+++ b/Octans.Client/Program.cs
@@ -28,8 +28,6 @@ builder.Services.AddOctansClient();
 builder.Services.AddInfrastructure();
 builder.Services.AddOctansServices();
 builder.Services.AddViewmodels();
-builder.Services.AddBusinessServices();
-builder.Services.AddChannels();
 builder.Services.AddDatabase();
 
 builder.Services.AddBandwidthLimiter(options =>

--- a/Octans.Client/ServiceCollectionExtensions.cs
+++ b/Octans.Client/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System.IO.Abstractions;
-using System.Threading.Channels;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -16,23 +15,9 @@ using Octans.Client.Components.Subscriptions;
 using Octans.Client.Services;
 using Octans.Client.Settings;
 using Octans.Core;
-using Octans.Core.Downloaders;
-using Octans.Core.Duplicates;
 using Octans.Core.Filesystem;
-using Octans.Core.Http;
-using Octans.Core.Http.Bandwidth;
-using Octans.Core.Importing;
-using Octans.Core.Importing.Filters;
 using Octans.Core.Importing.ImportFolders;
-using Octans.Core.Importing.RawByteProviders;
-using Octans.Core.Notes;
 using Octans.Core.Progress;
-using Octans.Core.Querying;
-using Octans.Core.Repositories;
-using Octans.Core.Scripting;
-using Octans.Core.Stats;
-using Octans.Core.Subscriptions;
-using Octans.Core.Tags;
 using Octans.Core.Thumbnails;
 using Octans.Data.Models;
 
@@ -56,104 +41,7 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddOctansServices(this IServiceCollection services)
     {
-        services.AddHostedService<ImportFolderBackgroundService>();
-        services.AddHostedService<ImportProcessorService>();
-        services.AddHostedService<SubscriptionBackgroundService>();
-        services.AddHostedService<RepositoryChangeBackgroundService>();
-
-        services.AddSingleton<IBackgroundProgressReporter, BackgroundProgressService>();
-        services.AddScoped<ImportFolderScanner>();
-        services.AddSingleton<RepositoryChangeProcessor>();
-
-        services.AddSingleton<ImageStorage>();
-        services.AddSingleton<StorageService>();
-        services.AddScoped<StatsService>();
-        services.AddScoped<SubscriptionService>();
-
-        return services;
-    }
-
-    public static void AddChannels(this IServiceCollection services)
-    {
-        var channel = Channel.CreateBounded<ThumbnailCreationRequest>(new BoundedChannelOptions(100)
-        {
-            FullMode = BoundedChannelFullMode.Wait
-        });
-
-        services.AddSingleton(channel.Reader);
-        services.AddSingleton(channel.Writer);
-
-        var repoChannel = Channel.CreateBounded<RepositoryChangeRequest>(new BoundedChannelOptions(100)
-        {
-            FullMode = BoundedChannelFullMode.Wait
-        });
-
-        services.AddSingleton(repoChannel.Reader);
-        services.AddSingleton(repoChannel.Writer);
-    }
-
-    public static void AddBusinessServices(this IServiceCollection services)
-    {
-        // Imports
-        services.AddScoped<SimpleImporter>();
-        services.AddScoped<FileImporter>();
-        services.AddScoped<PostImporter>();
-        services.AddScoped<ImportItemProcessor>();
-        services.AddScoped<IImporter, Importer>();
-        services.AddScoped<ImportJobService>();
-        services.AddScoped<IImportJobService>(s => s.GetRequiredService<ImportJobService>());
-        services.AddSingleton<IImportJobNotifier, NoOpImportJobNotifier>();
-
-        // Import services
-        services.AddScoped<ReimportChecker>();
-        services.AddScoped<DatabaseWriter>();
-        services.AddScoped<FilesystemWriter>();
-        services.AddScoped<ImportFilterService>();
-        services.AddSingleton<ThumbnailCreator>();
-        services.AddOptions<DownloaderResolverOptions>();
-        services.AddScoped<DownloaderFactory>();
-        services.AddScoped<DownloaderService>();
-
-        // Files
-        services.AddSingleton<ImageStorage>();
-        services.AddScoped<FileFinder>();
-        services.AddScoped<FileDeleter>();
-        services.AddScoped<TagUpdater>();
-        services.AddScoped<INoteService, NoteService>();
-
-        // Duplicates
-        services.AddScoped<IPerceptualHashProvider, PerceptualHashProvider>();
-        services.AddScoped<DuplicateService>();
-
-        services.AddSingleton(TimeProvider.System);
-        services.AddSingleton<IRobustFileWriter, RobustFileWriter>();
-        services.AddBandwidthLimiter();
-        services.AddDownloadManager();
-        services.AddMediator();
-
-        // Queries
-        services.AddScoped<IQueryService, QueryService>();
-        services.AddScoped<QueryParser>();
-        services.AddScoped<QueryPlanner>();
-        services.AddScoped<QueryTagConverter>();
-        services.AddScoped<HashSearcher>();
-        services.AddScoped<QuerySuggestionFinder>();
-        services.AddScoped<TagSplitter>();
-        services.AddScoped<TagSiblingService>();
-        services.AddScoped<TagParentService>();
-        services.AddScoped<ITagService, TagService>();
-
-        // Stats
-        services.AddScoped<StatsService>();
-        services.AddScoped<StorageService>();
-
-        // Scripting
-        services.AddScoped<ICustomCommandProvider, CustomCommandProvider>();
-
-        // Subscriptions
-        services.AddScoped<ISubscriptionExecutor, NoOpSubscriptionExecutor>();
-
-        services.AddMemoryCache();
+        return services.AddOctansCoreServices();
     }
 
     public static void AddDatabase(this IServiceCollection services)

--- a/Octans.Core/Downloaders/DownloaderFactory.cs
+++ b/Octans.Core/Downloaders/DownloaderFactory.cs
@@ -3,10 +3,17 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 namespace Octans.Core.Downloaders;
 
-public class DownloaderFactory(
+public interface IDownloaderFactory
+{
+    string DownloaderDirectory { get; }
+    Task<List<Downloader>> GetDownloaders();
+    Task<List<Downloader>> Rescan();
+}
+
+internal sealed class DownloaderFactory(
     IFileSystem fileSystem,
     IOptions<GlobalSettings> globalSettings,
-    ILogger<DownloaderFactory> logger)
+    ILogger<DownloaderFactory> logger) : IDownloaderFactory
 {
     private readonly GlobalSettings _globalSettings = globalSettings.Value;
 
@@ -14,7 +21,7 @@ public class DownloaderFactory(
 
     public string DownloaderDirectory => fileSystem.Path.Join(_globalSettings.AppRoot, "downloaders");
 
-    public virtual async Task<List<Downloader>> GetDownloaders()
+    public async Task<List<Downloader>> GetDownloaders()
     {
         if (_downloaders.Any())
         {

--- a/Octans.Core/Downloaders/DownloaderService.cs
+++ b/Octans.Core/Downloaders/DownloaderService.cs
@@ -5,9 +5,9 @@ using Octans.Core.Http;
 
 namespace Octans.Core.Downloaders;
 
-public class DownloaderService(
+internal sealed class DownloaderService(
     IHttpClientFactory clientFactory,
-    DownloaderFactory downloaderFactory,
+    IDownloaderFactory downloaderFactory,
     IDownloadRequestHeaderProvider requestHeaderProvider,
     IOptions<DownloaderResolverOptions> options,
     ILogger<DownloaderService> logger)

--- a/Octans.Core/Duplicates/DuplicateService.cs
+++ b/Octans.Core/Duplicates/DuplicateService.cs
@@ -8,7 +8,7 @@ using Octans.Data.Models.Duplicates;
 
 namespace Octans.Core.Duplicates;
 
-public class DuplicateService(
+public sealed class DuplicateService(
     ServerDbContext context,
     IPerceptualHashProvider hashProvider,
     ImageStorage imageStorage,

--- a/Octans.Core/Duplicates/PerceptualHashProvider.cs
+++ b/Octans.Core/Duplicates/PerceptualHashProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Octans.Core.Duplicates;
 
-public class PerceptualHashProvider(ILogger<PerceptualHashProvider> logger) : IPerceptualHashProvider
+internal sealed class PerceptualHashProvider(ILogger<PerceptualHashProvider> logger) : IPerceptualHashProvider
 {
     public Task<ulong> GetHash(Stream imageStream, CancellationToken cancellationToken = default)
     {

--- a/Octans.Core/Extensions/ListExtensions.cs
+++ b/Octans.Core/Extensions/ListExtensions.cs
@@ -4,7 +4,7 @@ namespace Octans.Core.Extensions;
 
 public static class ListExtensions
 {
-    public static (List<T1>, List<T2>, List<T3>) Partition<T1, T2, T3>(this IEnumerable<IPredicate> source)
+    internal static (List<T1>, List<T2>, List<T3>) Partition<T1, T2, T3>(this IEnumerable<IPredicate> source)
         where T1 : IPredicate
         where T2 : IPredicate
         where T3 : IPredicate

--- a/Octans.Core/Filesystem/FileDeleter.cs
+++ b/Octans.Core/Filesystem/FileDeleter.cs
@@ -6,7 +6,7 @@ public record DeleteResult(int Id, bool Success, string? Error);
 public record DeleteRequest(IEnumerable<int> Ids);
 public record DeleteResponse(List<DeleteResult> Results);
 
-public class FileDeleter(ImageStorage imageStorage, ServerDbContext context, TimeProvider timeProvider)
+public sealed class FileDeleter(ImageStorage imageStorage, ServerDbContext context, TimeProvider timeProvider)
 {
     public async Task<List<DeleteResult>> ProcessDeletion(IEnumerable<int> request)
     {

--- a/Octans.Core/Filesystem/ImageStorage.cs
+++ b/Octans.Core/Filesystem/ImageStorage.cs
@@ -6,7 +6,7 @@ namespace Octans.Core.Filesystem;
 
 public sealed record ImageMetadata(string Extension, string ContentType);
 
-public class ImageStorage(IOptions<GlobalSettings> settings, IFileSystem fileSystem)
+public sealed class ImageStorage(IOptions<GlobalSettings> settings, IFileSystem fileSystem)
 {
     private const string Hexadecimal = "0123456789abcdef";
 

--- a/Octans.Core/Filesystem/RobustFileWriter.cs
+++ b/Octans.Core/Filesystem/RobustFileWriter.cs
@@ -7,13 +7,13 @@ namespace Octans.Core.Filesystem;
 /// Shared helpers for writing files through staging paths and managing
 /// temporary files that must be cleaned up after use.
 /// </summary>
-public interface IRobustFileWriter
+internal interface IRobustFileWriter
 {
     Task WriteAllBytesAsync(string destinationPath, byte[] bytes, CancellationToken cancellationToken = default);
     RobustTemporaryFile CreateTemporaryFile(string directoryPath, string suggestedFileName);
 }
 
-public sealed class RobustFileWriter(
+internal sealed class RobustFileWriter(
     IFileSystem fileSystem,
     ILogger<RobustFileWriter> logger) : IRobustFileWriter
 {
@@ -97,7 +97,7 @@ public sealed class RobustFileWriter(
     }
 }
 
-public sealed class RobustTemporaryFile(string path, Action<string> cleanup) : IDisposable
+internal sealed class RobustTemporaryFile(string path, Action<string> cleanup) : IDisposable
 {
     private bool _disposed;
 

--- a/Octans.Core/Http/ActiveDownloadRegistry.cs
+++ b/Octans.Core/Http/ActiveDownloadRegistry.cs
@@ -17,7 +17,7 @@ public interface IActiveDownloadRegistry
 /// <summary>
 /// In-memory cancellation-token registry for active transfers.
 /// </summary>
-public sealed class ActiveDownloadRegistry(
+internal sealed class ActiveDownloadRegistry(
     ILogger<ActiveDownloadRegistry> logger) : IActiveDownloadRegistry, IDisposable, IAsyncDisposable
 {
     private readonly CancellationTokenSource _globalCancellation = new();

--- a/Octans.Core/Http/Bandwidth/DownloadBandwidthGate.cs
+++ b/Octans.Core/Http/Bandwidth/DownloadBandwidthGate.cs
@@ -13,7 +13,7 @@ public interface IDownloadBandwidthGate
 /// <summary>
 /// Bandwidth gate used when byte pacing is not configured.
 /// </summary>
-public sealed class NoOpDownloadBandwidthGate : IDownloadBandwidthGate
+internal sealed class NoOpDownloadBandwidthGate : IDownloadBandwidthGate
 {
     public Task WaitForBytesAsync(string domain, long byteCount, CancellationToken cancellationToken)
     {
@@ -24,7 +24,7 @@ public sealed class NoOpDownloadBandwidthGate : IDownloadBandwidthGate
 /// <summary>
 /// Token-bucket bandwidth gate that applies both global and per-domain limits.
 /// </summary>
-public sealed class DownloadBandwidthGate(
+internal sealed class DownloadBandwidthGate(
     IOptions<BandwidthLimiterOptions> options,
     TimeProvider timeProvider) : IDownloadBandwidthGate
 {

--- a/Octans.Core/Http/DatabaseDownloadQueue.cs
+++ b/Octans.Core/Http/DatabaseDownloadQueue.cs
@@ -24,7 +24,7 @@ public interface IDownloadQueue
 /// Entity Framework implementation of the download queue.
 /// </summary>
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix")]
-public class DatabaseDownloadQueue(
+internal sealed class DatabaseDownloadQueue(
     IDbContextFactory<ServerDbContext> contextFactory,
     ILogger<DatabaseDownloadQueue> logger,
     DownloadTelemetry telemetry) : IDownloadQueue

--- a/Octans.Core/Http/DownloadBackgroundService.cs
+++ b/Octans.Core/Http/DownloadBackgroundService.cs
@@ -10,7 +10,7 @@ namespace Octans.Core.Http;
 /// Hosted worker that drains the durable download queue while enforcing global
 /// and per-domain concurrency limits.
 /// </summary>
-public sealed class DownloadBackgroundService(
+internal sealed class DownloadBackgroundService(
     IDownloadQueue downloadQueue,
     IDownloadStateService stateService,
     HttpDownloader processor,

--- a/Octans.Core/Http/DownloadCompletionNotifier.cs
+++ b/Octans.Core/Http/DownloadCompletionNotifier.cs
@@ -14,7 +14,7 @@ public interface IDownloadCompletionNotifier
 /// <summary>
 /// Default notifier used when no feature has registered download completion work.
 /// </summary>
-public sealed class NoOpDownloadCompletionNotifier : IDownloadCompletionNotifier
+internal sealed class NoOpDownloadCompletionNotifier : IDownloadCompletionNotifier
 {
     public Task DownloadFinishedAsync(DownloadJobResult result, CancellationToken cancellationToken = default)
     {

--- a/Octans.Core/Http/DownloadCompletionWaiter.cs
+++ b/Octans.Core/Http/DownloadCompletionWaiter.cs
@@ -23,7 +23,7 @@ public interface IDownloadCompletionWaiter
 /// Async completion waiter backed by in-process state-change notifications and
 /// a durable database polling fallback.
 /// </summary>
-public sealed class DownloadCompletionWaiter(
+internal sealed class DownloadCompletionWaiter(
     IDownloadStateService stateService,
     IDownloadJobResultService jobResults,
     TimeProvider timeProvider,

--- a/Octans.Core/Http/DownloadDiskSpaceGuard.cs
+++ b/Octans.Core/Http/DownloadDiskSpaceGuard.cs
@@ -17,7 +17,7 @@ public interface IDownloadDiskSpaceGuard
 /// <summary>
 /// Best-effort free-space guard used before and during streamed writes.
 /// </summary>
-public sealed class DownloadDiskSpaceGuard(
+internal sealed class DownloadDiskSpaceGuard(
     IFileSystem fileSystem,
     IOptions<DownloadManagerOptions> options,
     ILogger<DownloadDiskSpaceGuard> logger) : IDownloadDiskSpaceGuard

--- a/Octans.Core/Http/DownloadHostCircuitRegistry.cs
+++ b/Octans.Core/Http/DownloadHostCircuitRegistry.cs
@@ -17,7 +17,7 @@ public interface IDownloadHostCircuitRegistry
 /// In-memory registry used by the HTTP resilience pipeline and queue scheduler
 /// to avoid dispatching work to temporarily unavailable hosts.
 /// </summary>
-public sealed class DownloadHostCircuitRegistry(
+internal sealed class DownloadHostCircuitRegistry(
     TimeProvider timeProvider,
     ILogger<DownloadHostCircuitRegistry> logger,
     DownloadTelemetry telemetry) : IDownloadHostCircuitRegistry

--- a/Octans.Core/Http/DownloadJobResults.cs
+++ b/Octans.Core/Http/DownloadJobResults.cs
@@ -16,7 +16,7 @@ public interface IDownloadJobResultService
 /// <summary>
 /// Entity Framework implementation of terminal download result lookup.
 /// </summary>
-public sealed class DownloadJobResultService(IDbContextFactory<ServerDbContext> contextFactory)
+internal sealed class DownloadJobResultService(IDbContextFactory<ServerDbContext> contextFactory)
     : IDownloadJobResultService
 {
     public async Task<DownloadJobResult?> GetResultAsync(Guid id, CancellationToken cancellationToken = default)

--- a/Octans.Core/Http/DownloadLifecycleService.cs
+++ b/Octans.Core/Http/DownloadLifecycleService.cs
@@ -31,7 +31,7 @@ public interface IDownloadLifecycleService
 /// <summary>
 /// Owns user-visible download lifecycle commands and terminal transitions.
 /// </summary>
-public sealed class DownloadLifecycleService(
+internal sealed class DownloadLifecycleService(
     IDownloadStateService stateService,
     IActiveDownloadRegistry activeDownloads,
     IDownloadCompletionNotifier completionNotifier,

--- a/Octans.Core/Http/DownloadRequestHeaderProvider.cs
+++ b/Octans.Core/Http/DownloadRequestHeaderProvider.cs
@@ -19,7 +19,7 @@ public interface IDownloadRequestHeaderProvider
 /// <summary>
 /// Applies global and per-domain HTTP request header configuration.
 /// </summary>
-public sealed class DownloadRequestHeaderProvider(IOptions<DownloadManagerOptions> options) : IDownloadRequestHeaderProvider
+internal sealed class DownloadRequestHeaderProvider(IOptions<DownloadManagerOptions> options) : IDownloadRequestHeaderProvider
 {
     private static readonly HashSet<string> SensitiveHeaderNames = new(StringComparer.OrdinalIgnoreCase)
     {

--- a/Octans.Core/Http/DownloadService.cs
+++ b/Octans.Core/Http/DownloadService.cs
@@ -33,7 +33,7 @@ public interface IDownloadService
 /// Thin facade that keeps callers on the stable download API while delegating
 /// lifecycle changes and terminal-result queries to dedicated services.
 /// </summary>
-public sealed class DownloadService(
+internal sealed class DownloadService(
     IDownloadLifecycleService lifecycle,
     IDownloadJobResultService jobResults,
     IDownloadCompletionWaiter completionWaiter) : IDownloadService

--- a/Octans.Core/Http/DownloadStagingPaths.cs
+++ b/Octans.Core/Http/DownloadStagingPaths.cs
@@ -6,7 +6,7 @@ namespace Octans.Core.Http;
 /// <summary>
 /// Builds and manages temporary staging paths for in-progress HTTP downloads.
 /// </summary>
-public sealed class DownloadStagingPaths(IFileSystem fileSystem)
+internal sealed class DownloadStagingPaths(IFileSystem fileSystem)
 {
     private const string StagingDirectoryName = ".octans-downloads";
 

--- a/Octans.Core/Http/DownloadStatusTracker.cs
+++ b/Octans.Core/Http/DownloadStatusTracker.cs
@@ -42,7 +42,7 @@ public delegate ValueTask DownloadStatusChangedHandler(DownloadStatusChanged not
 /// <summary>
 /// Database-backed download state service that raises UI-friendly change events.
 /// </summary>
-public class DownloadStatusTracker(
+internal sealed class DownloadStatusTracker(
     IDbContextFactory<ServerDbContext> contextFactory,
     TimeProvider timeProvider,
     ILogger<DownloadStatusTracker> logger) : IDownloadStateService

--- a/Octans.Core/Http/HttpDownloader.cs
+++ b/Octans.Core/Http/HttpDownloader.cs
@@ -16,7 +16,7 @@ namespace Octans.Core.Http;
 /// Streams queued HTTP downloads into staging files, validates the response and
 /// final payload, then commits successful downloads to their destination path.
 /// </summary>
-public class HttpDownloader(
+internal sealed class HttpDownloader(
     IDownloadBandwidthGate bandwidthGate,
     IDownloadDiskSpaceGuard diskSpaceGuard,
     IDownloadStateService stateService,

--- a/Octans.Core/Importing/DatabaseWriter.cs
+++ b/Octans.Core/Importing/DatabaseWriter.cs
@@ -7,7 +7,7 @@ using Octans.Data.Models.Tagging;
 
 namespace Octans.Core.Importing;
 
-public class DatabaseWriter(ServerDbContext context, ILogger<DatabaseWriter> logger)
+internal sealed class DatabaseWriter(ServerDbContext context, ILogger<DatabaseWriter> logger)
 {
     public async Task AddItemToDatabase(ImportItem item, ContentHash hash, ImageMetadata metadata, bool autoArchive)
     {

--- a/Octans.Core/Importing/FilesystemWriter.cs
+++ b/Octans.Core/Importing/FilesystemWriter.cs
@@ -3,7 +3,7 @@ using Octans.Core.Filesystem;
 
 namespace Octans.Core.Importing;
 
-public class FilesystemWriter(
+internal sealed class FilesystemWriter(
     ImageStorage imageStorage,
     IRobustFileWriter fileWriter,
     ILogger<FilesystemWriter> logger)

--- a/Octans.Core/Importing/Filters/ImportFilterService.cs
+++ b/Octans.Core/Importing/Filters/ImportFilterService.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Octans.Core.Importing.Filters;
 
-public sealed class ImportFilterService(ILogger<ImportFilterService> logger)
+internal sealed class ImportFilterService(ILogger<ImportFilterService> logger)
 {
     public async Task<ImportItemResult?> ApplyFilters(ImportRequest request, byte[] bytes)
     {

--- a/Octans.Core/Importing/Filters/ImportFilters.cs
+++ b/Octans.Core/Importing/Filters/ImportFilters.cs
@@ -3,12 +3,12 @@ using SixLabors.ImageSharp;
 
 namespace Octans.Core.Importing.Filters;
 
-public interface IImportFilter
+internal interface IImportFilter
 {
     Task<bool> PassesFilter(ImportFilterData request, byte[] bytes, CancellationToken cancellationToken = default);
 }
 
-public class ResolutionFilter : IImportFilter
+internal sealed class ResolutionFilter : IImportFilter
 {
     public Task<bool> PassesFilter(ImportFilterData request, byte[] bytes, CancellationToken cancellationToken = default)
     {
@@ -40,7 +40,7 @@ public class ResolutionFilter : IImportFilter
     }
 }
 
-public class FiletypeFilter : IImportFilter
+internal sealed class FiletypeFilter : IImportFilter
 {
     public Task<bool> PassesFilter(ImportFilterData request, byte[] bytes, CancellationToken cancellationToken = default)
     {
@@ -61,7 +61,7 @@ public class FiletypeFilter : IImportFilter
     }
 }
 
-public class FilesizeFilter : IImportFilter
+internal sealed class FilesizeFilter : IImportFilter
 {
     public Task<bool> PassesFilter(ImportFilterData request, byte[] bytes, CancellationToken cancellationToken = default)
     {

--- a/Octans.Core/Importing/ImportFolders/ImportFolderBackgroundService.cs
+++ b/Octans.Core/Importing/ImportFolders/ImportFolderBackgroundService.cs
@@ -7,7 +7,7 @@ using Octans.Core.Progress;
 
 namespace Octans.Core.Importing.ImportFolders;
 
-public sealed class ImportFolderBackgroundService(
+internal sealed class ImportFolderBackgroundService(
     IOptions<ImportFolderOptions> options,
     IServiceScopeFactory scopeFactory,
     ILogger<ImportFolderBackgroundService> logger) : BackgroundService
@@ -33,7 +33,7 @@ public sealed class ImportFolderBackgroundService(
     }
 }
 
-public sealed class ImportFolderScanner(
+internal sealed class ImportFolderScanner(
     IOptions<ImportFolderOptions> options,
     IFileSystem fileSystem,
     IBackgroundProgressReporter progressReporter,

--- a/Octans.Core/Importing/ImportItemProcessor.cs
+++ b/Octans.Core/Importing/ImportItemProcessor.cs
@@ -7,7 +7,7 @@ using Octans.Core.Thumbnails;
 
 namespace Octans.Core.Importing;
 
-public class ImportItemProcessor(
+internal sealed class ImportItemProcessor(
     ImportFilterService filterService,
     ReimportChecker reimportChecker,
     DatabaseWriter databaseWriter,

--- a/Octans.Core/Importing/ImportJobService.cs
+++ b/Octans.Core/Importing/ImportJobService.cs
@@ -12,12 +12,12 @@ using DataImportType = Octans.Data.Models.Importing.ImportType;
 
 namespace Octans.Core.Importing;
 
-public interface IImportJobNotifier
+internal interface IImportJobNotifier
 {
     Task JobChanged(Guid jobId, CancellationToken cancellationToken = default);
 }
 
-public sealed class NoOpImportJobNotifier : IImportJobNotifier
+internal sealed class NoOpImportJobNotifier : IImportJobNotifier
 {
     public Task JobChanged(Guid jobId, CancellationToken cancellationToken = default) => Task.CompletedTask;
 }
@@ -32,7 +32,7 @@ public interface IImportJobService
     Task<ImportJobDto?> CancelJob(Guid id, CancellationToken cancellationToken = default);
 }
 
-public class ImportJobService(
+internal sealed class ImportJobService(
     ServerDbContext context,
     TimeProvider timeProvider,
     IImportJobNotifier notifier,

--- a/Octans.Core/Importing/ImportProcessorService.cs
+++ b/Octans.Core/Importing/ImportProcessorService.cs
@@ -9,7 +9,7 @@ using DataImportJobStatus = Octans.Data.Models.Importing.ImportJobStatus;
 
 namespace Octans.Core.Importing;
 
-public class ImportProcessorService(
+internal sealed class ImportProcessorService(
     IServiceProvider serviceProvider,
     ILogger<ImportProcessorService> logger) : BackgroundService
 {

--- a/Octans.Core/Importing/Importer.cs
+++ b/Octans.Core/Importing/Importer.cs
@@ -9,7 +9,7 @@ public interface IImporter
     Task<ImportResult> ProcessImport(ImportRequest request, Guid progressId, CancellationToken cancellationToken = default);
 }
 
-public class Importer(
+internal sealed class Importer(
     ImportItemProcessor itemProcessor,
     IBackgroundProgressReporter progress,
     ILogger<Importer> logger) : IImporter

--- a/Octans.Core/Importing/RawByteProviders/FileImporter.cs
+++ b/Octans.Core/Importing/RawByteProviders/FileImporter.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Octans.Core.Importing.RawByteProviders;
 
-public class FileImporter(IFileSystem fileSystem, ILogger<FileImporter> logger) : IRawByteProvider
+internal sealed class FileImporter(IFileSystem fileSystem, ILogger<FileImporter> logger) : IRawByteProvider
 {
     public async Task<byte[]> GetRawBytes(ImportItem item)
     {

--- a/Octans.Core/Importing/RawByteProviders/IRawByteProvider.cs
+++ b/Octans.Core/Importing/RawByteProviders/IRawByteProvider.cs
@@ -1,6 +1,6 @@
 namespace Octans.Core.Importing.RawByteProviders;
 
-public interface IRawByteProvider
+internal interface IRawByteProvider
 {
     Task<byte[]> GetRawBytes(ImportItem item);
 }

--- a/Octans.Core/Importing/RawByteProviders/PostImporter.cs
+++ b/Octans.Core/Importing/RawByteProviders/PostImporter.cs
@@ -4,7 +4,7 @@ using Octans.Core.Http;
 
 namespace Octans.Core.Importing.RawByteProviders;
 
-public class PostImporter(
+internal sealed class PostImporter(
     DownloaderService downloaderService,
     IDownloadService downloadService,
     IFileSystem fileSystem)

--- a/Octans.Core/Importing/RawByteProviders/SimpleImporter.cs
+++ b/Octans.Core/Importing/RawByteProviders/SimpleImporter.cs
@@ -10,7 +10,7 @@ namespace Octans.Core.Importing.RawByteProviders;
 /// <summary>
 /// Handles the importing of resources from local and remote sources.
 /// </summary>
-public sealed class SimpleImporter(
+internal sealed class SimpleImporter(
     IDownloadService downloadService,
     IRobustFileWriter fileWriter,
     IFileSystem fileSystem,

--- a/Octans.Core/Importing/ReimportChecker.cs
+++ b/Octans.Core/Importing/ReimportChecker.cs
@@ -5,7 +5,7 @@ using Octans.Data.Models;
 
 namespace Octans.Core.Importing;
 
-public class ReimportChecker(
+internal sealed class ReimportChecker(
     ServerDbContext context,
     ImageStorage imageStorage,
     FilesystemWriter filesystemWriter,

--- a/Octans.Core/Notes/NoteService.cs
+++ b/Octans.Core/Notes/NoteService.cs
@@ -3,7 +3,7 @@ using Octans.Data.Models;
 
 namespace Octans.Core.Notes;
 
-public class NoteService(ServerDbContext context, TimeProvider timeProvider) : INoteService
+internal sealed class NoteService(ServerDbContext context, TimeProvider timeProvider) : INoteService
 {
     public async Task<List<NoteDto>> GetNotesAsync(string hash)
     {

--- a/Octans.Core/Progress/BackgroundProgressService.cs
+++ b/Octans.Core/Progress/BackgroundProgressService.cs
@@ -16,7 +16,7 @@ public interface IBackgroundProgressReporter
     Task ReportError(string message);
 }
 
-public class BackgroundProgressService(ILogger<BackgroundProgressService> logger, IServiceScopeFactory scopeFactory)
+internal sealed class BackgroundProgressService(ILogger<BackgroundProgressService> logger, IServiceScopeFactory scopeFactory)
     : IBackgroundProgressReporter
 {
     private readonly ConcurrentDictionary<Guid, ProgressStatus> _operations = new();

--- a/Octans.Core/Properties/AssemblyInfo.cs
+++ b/Octans.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Octans.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Octans.Core/Querying/FileFinder.cs
+++ b/Octans.Core/Querying/FileFinder.cs
@@ -5,7 +5,7 @@ using Octans.Data.Models.Tagging;
 
 namespace Octans.Core.Querying;
 
-public class FileFinder(ImageStorage imageStorage, ServerDbContext context)
+public sealed class FileFinder(ImageStorage imageStorage, ServerDbContext context)
 {
     public async Task<List<HashItem>> GetAll()
     {

--- a/Octans.Core/Querying/HashSearcher.cs
+++ b/Octans.Core/Querying/HashSearcher.cs
@@ -7,7 +7,7 @@ namespace Octans.Core.Querying;
 /// <summary>
 /// Executes a query plan against the database and returns the relevant hashes.
 /// </summary>
-public class HashSearcher(ServerDbContext context, TagParentService tagParentService)
+internal sealed class HashSearcher(ServerDbContext context, TagParentService tagParentService)
 {
     public async Task<int> CountAsync(DecomposedQuery request, CancellationToken cancellationToken = default)
     {

--- a/Octans.Core/Querying/Predicates.cs
+++ b/Octans.Core/Querying/Predicates.cs
@@ -4,9 +4,9 @@ using Octans.Data.Models;
 namespace Octans.Core.Querying;
 
 [SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "Required at compile-time")]
-public interface IPredicate;
+internal interface IPredicate;
 
-public class TagPredicate : IPredicate
+internal sealed class TagPredicate : IPredicate
 {
     public required string NamespacePattern { get; set; }
     public required string SubtagPattern { get; set; }
@@ -21,24 +21,24 @@ public class TagPredicate : IPredicate
     public bool IsSpecificTag() => !IsWildcard();
 }
 
-public abstract class SystemPredicate : IPredicate
+internal abstract class SystemPredicate : IPredicate
 {
 }
 
-public class FilesizePredicate : SystemPredicate
+internal sealed class FilesizePredicate : SystemPredicate
 {
 }
 
-public class EverythingPredicate : SystemPredicate
+internal sealed class EverythingPredicate : SystemPredicate
 {
 }
 
-public class RepositoryPredicate : SystemPredicate
+internal sealed class RepositoryPredicate : SystemPredicate
 {
     public required RepositoryType Repository { get; init; }
 }
 
-public class OrPredicate : IPredicate
+internal sealed class OrPredicate : IPredicate
 {
     public List<IPredicate> Predicates { get; init; } = [];
 }

--- a/Octans.Core/Querying/QueryParser.cs
+++ b/Octans.Core/Querying/QueryParser.cs
@@ -6,7 +6,7 @@ namespace Octans.Core.Querying;
 /// <summary>
 /// Converts raw strings represent components of a query into strongly-typed predicates.
 /// </summary>
-public class QueryParser
+internal sealed class QueryParser
 {
     public List<IPredicate> Parse(IEnumerable<string> queries)
     {
@@ -123,7 +123,7 @@ public class QueryParser
 /// A raw string from the user that has undergone whitespace removal and colon-splitting,
 /// but hasn't yet been parsed as a system predicate, tag predicate, etc. 
 /// </summary>
-public class RawQuery
+internal sealed class RawQuery
 {
     public required string Prefix { get; init; }
     public required string Query { get; init; }

--- a/Octans.Core/Querying/QueryPlanner.cs
+++ b/Octans.Core/Querying/QueryPlanner.cs
@@ -7,7 +7,7 @@ namespace Octans.Core.Querying;
 /// Service for optimising a set of generated predicates.
 /// Removes duplicates, short-circuits in case of negating predicates, removes redundant predicates, etc.
 /// </summary>
-public class QueryPlanner(IMemoryCache memoryCache)
+internal sealed class QueryPlanner(IMemoryCache memoryCache)
 {
     public QueryPlan OptimiseQuery(IList<IPredicate> predicates)
     {
@@ -59,7 +59,7 @@ public class QueryPlanner(IMemoryCache memoryCache)
     }
 }
 
-public class QueryPlan
+internal sealed class QueryPlan
 {
     public required List<IPredicate> Predicates { get; init; }
 

--- a/Octans.Core/Querying/QueryService.cs
+++ b/Octans.Core/Querying/QueryService.cs
@@ -9,7 +9,7 @@ public interface IQueryService
     IAsyncEnumerable<HashItem> Query(IEnumerable<string> queries, CancellationToken cancellationToken = default);
 }
 
-public class QueryService(QueryParser parser, QueryPlanner planner, QueryTagConverter converter, HashSearcher searcher) : IQueryService
+internal sealed class QueryService(QueryParser parser, QueryPlanner planner, QueryTagConverter converter, HashSearcher searcher) : IQueryService
 {
     public async Task<int> CountAsync(IEnumerable<string> queries, CancellationToken cancellationToken = default)
     {

--- a/Octans.Core/Querying/QuerySuggestionFinder.cs
+++ b/Octans.Core/Querying/QuerySuggestionFinder.cs
@@ -8,7 +8,7 @@ namespace Octans.Core.Querying;
 /// <summary>
 /// Provides suggestions on relevant tags given text, e.g. for autocomplete dropdowns.
 /// </summary>
-public class QuerySuggestionFinder(ServerDbContext context, TagSplitter splitter)
+public sealed class QuerySuggestionFinder(ServerDbContext context, TagSplitter splitter)
 {
     public async Task<HashSet<Tag>> GetAutocompleteTagIds(string search, bool exact, CancellationToken token = default)
     {

--- a/Octans.Core/Querying/QueryTagConverter.cs
+++ b/Octans.Core/Querying/QueryTagConverter.cs
@@ -7,7 +7,7 @@ namespace Octans.Core.Querying;
 /// <summary>
 /// Converts a rich query plan composed of IPredicates into 'raw' lists of tags/namespaces to include/exclude.
 /// </summary>
-public class QueryTagConverter
+internal sealed class QueryTagConverter
 {
     public DecomposedQuery Reduce(QueryPlan plan)
     {
@@ -89,7 +89,7 @@ public class QueryTagConverter
     }
 }
 
-public class DecomposedQuery
+internal sealed class DecomposedQuery
 {
     public List<SystemPredicate> SystemPredicates { get; init; } = [];
     public List<RepositoryType> RepositoryFilters { get; init; } = [];

--- a/Octans.Core/Repositories/RepositoryChangeBackgroundService.cs
+++ b/Octans.Core/Repositories/RepositoryChangeBackgroundService.cs
@@ -7,7 +7,7 @@ using Octans.Data.Models;
 
 namespace Octans.Core.Repositories;
 
-public sealed class RepositoryChangeBackgroundService(
+internal sealed class RepositoryChangeBackgroundService(
     ChannelReader<RepositoryChangeRequest> channel,
     RepositoryChangeProcessor processor) : BackgroundService
 {
@@ -35,7 +35,7 @@ public sealed class RepositoryChangeBackgroundService(
     }
 }
 
-public sealed class RepositoryChangeProcessor(
+internal sealed class RepositoryChangeProcessor(
     IDbContextFactory<ServerDbContext> contextFactory,
     IBackgroundProgressReporter progressReporter,
     ILogger<RepositoryChangeProcessor> logger)

--- a/Octans.Core/Scripting/CustomCommandProvider.cs
+++ b/Octans.Core/Scripting/CustomCommandProvider.cs
@@ -7,7 +7,7 @@ namespace Octans.Core.Scripting;
 
 public record ImageCommandMetadata(string Name, string Description, string Icon);
 
-public sealed class CustomCommandProvider(
+internal sealed class CustomCommandProvider(
     IFileSystem fileSystem,
     IOptions<GlobalSettings> globalSettings,
     ILogger<CustomCommandProvider> logger) : ICustomCommandProvider

--- a/Octans.Core/ServiceCollectionExtensions.cs
+++ b/Octans.Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,132 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Octans.Core.Downloaders;
+using Octans.Core.Duplicates;
+using Octans.Core.Filesystem;
+using Octans.Core.Http;
+using Octans.Core.Http.Bandwidth;
+using Octans.Core.Importing;
+using Octans.Core.Importing.Filters;
+using Octans.Core.Importing.ImportFolders;
+using Octans.Core.Importing.RawByteProviders;
+using Octans.Core.Notes;
+using Octans.Core.Progress;
+using Octans.Core.Querying;
+using Octans.Core.Repositories;
+using Octans.Core.Scripting;
+using Octans.Core.Stats;
+using Octans.Core.Subscriptions;
+using Octans.Core.Tags;
+using Octans.Core.Thumbnails;
+
+namespace Octans.Core;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddOctansCoreServices(this IServiceCollection services)
+    {
+        services.AddOctansChannels();
+
+        services.AddHostedService<ImportFolderBackgroundService>();
+        services.AddHostedService<ImportProcessorService>();
+        services.AddHostedService<SubscriptionBackgroundService>();
+        services.AddHostedService<RepositoryChangeBackgroundService>();
+
+        services.AddSingleton<IBackgroundProgressReporter, BackgroundProgressService>();
+        services.AddScoped<ImportFolderScanner>();
+        services.AddSingleton<RepositoryChangeProcessor>();
+
+        services.AddBusinessServices();
+
+        return services;
+    }
+
+    public static IServiceCollection AddOctansChannels(this IServiceCollection services)
+    {
+        var channel = Channel.CreateBounded<ThumbnailCreationRequest>(new BoundedChannelOptions(100)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        });
+
+        services.AddSingleton(channel.Reader);
+        services.AddSingleton(channel.Writer);
+
+        var repoChannel = Channel.CreateBounded<RepositoryChangeRequest>(new BoundedChannelOptions(100)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        });
+
+        services.AddSingleton(repoChannel.Reader);
+        services.AddSingleton(repoChannel.Writer);
+
+        return services;
+    }
+
+    public static IServiceCollection AddBusinessServices(this IServiceCollection services)
+    {
+        // Imports
+        services.AddScoped<SimpleImporter>();
+        services.AddScoped<FileImporter>();
+        services.AddScoped<PostImporter>();
+        services.AddScoped<ImportItemProcessor>();
+        services.AddScoped<IImporter, Importer>();
+        services.AddScoped<ImportJobService>();
+        services.AddScoped<IImportJobService>(s => s.GetRequiredService<ImportJobService>());
+        services.AddSingleton<IImportJobNotifier, NoOpImportJobNotifier>();
+
+        // Import services
+        services.AddScoped<ReimportChecker>();
+        services.AddScoped<DatabaseWriter>();
+        services.AddScoped<FilesystemWriter>();
+        services.AddScoped<ImportFilterService>();
+        services.AddSingleton<ThumbnailCreator>();
+        services.AddOptions<DownloaderResolverOptions>();
+        services.AddScoped<DownloaderFactory>();
+        services.AddScoped<IDownloaderFactory>(s => s.GetRequiredService<DownloaderFactory>());
+        services.AddScoped<DownloaderService>();
+
+        // Files
+        services.AddSingleton<ImageStorage>();
+        services.AddScoped<FileFinder>();
+        services.AddScoped<FileDeleter>();
+        services.AddScoped<TagUpdater>();
+        services.AddScoped<INoteService, NoteService>();
+
+        // Duplicates
+        services.AddScoped<IPerceptualHashProvider, PerceptualHashProvider>();
+        services.AddScoped<DuplicateService>();
+
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<IRobustFileWriter, RobustFileWriter>();
+        services.AddBandwidthLimiter();
+        services.AddDownloadManager();
+
+        // Queries
+        services.AddScoped<IQueryService, QueryService>();
+        services.AddScoped<QueryParser>();
+        services.AddScoped<QueryPlanner>();
+        services.AddScoped<QueryTagConverter>();
+        services.AddScoped<HashSearcher>();
+        services.AddScoped<QuerySuggestionFinder>();
+        services.AddScoped<TagSplitter>();
+        services.AddScoped<TagSiblingService>();
+        services.AddScoped<TagParentService>();
+        services.AddScoped<ITagService, TagService>();
+
+        // Stats
+        services.AddScoped<StatsService>();
+        services.AddScoped<StorageService>();
+
+        // Scripting
+        services.AddScoped<ICustomCommandProvider, CustomCommandProvider>();
+
+        // Subscriptions
+        services.AddScoped<ISubscriptionService, SubscriptionService>();
+        services.AddScoped<ISubscriptionExecutor, NoOpSubscriptionExecutor>();
+
+        services.AddMemoryCache();
+
+        return services;
+    }
+}

--- a/Octans.Core/Stats/StatsService.cs
+++ b/Octans.Core/Stats/StatsService.cs
@@ -3,7 +3,7 @@ using Octans.Data.Models;
 
 namespace Octans.Core.Stats;
 
-public class StatsService(ServerDbContext dbContext, StorageService storageService)
+public sealed class StatsService(ServerDbContext dbContext, StorageService storageService)
 {
     public async Task<HomeStats> GetHomeStats()
     {

--- a/Octans.Core/Stats/StorageService.cs
+++ b/Octans.Core/Stats/StorageService.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Options;
 
 namespace Octans.Core.Stats;
 
-public class StorageService(IFileSystem fileSystem, IOptions<GlobalSettings> settings)
+public sealed class StorageService(IFileSystem fileSystem, IOptions<GlobalSettings> settings)
 {
     private readonly string _appRoot = settings.Value.AppRoot;
 

--- a/Octans.Core/Subscriptions/ISubscriptionExecutor.cs
+++ b/Octans.Core/Subscriptions/ISubscriptionExecutor.cs
@@ -7,7 +7,7 @@ public interface ISubscriptionExecutor
     Task<SubscriptionExecutionResult> ExecuteAsync(Subscription subscription, CancellationToken cancellationToken);
 }
 
-public class NoOpSubscriptionExecutor : ISubscriptionExecutor
+internal sealed class NoOpSubscriptionExecutor : ISubscriptionExecutor
 {
     public Task<SubscriptionExecutionResult> ExecuteAsync(Subscription subscription,
         CancellationToken cancellationToken) =>

--- a/Octans.Core/Subscriptions/SubscriptionBackgroundService.cs
+++ b/Octans.Core/Subscriptions/SubscriptionBackgroundService.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Octans.Core.Subscriptions;
 
-public class SubscriptionBackgroundService(
+internal sealed class SubscriptionBackgroundService(
     IServiceProvider serviceProvider,
     ILogger<SubscriptionBackgroundService> logger,
     TimeProvider timeProvider) : BackgroundService
@@ -12,7 +12,7 @@ public class SubscriptionBackgroundService(
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         using var scope = serviceProvider.CreateScope();
-        var service = scope.ServiceProvider.GetRequiredService<SubscriptionService>();
+        var service = scope.ServiceProvider.GetRequiredService<ISubscriptionService>();
 
         try
         {

--- a/Octans.Core/Subscriptions/SubscriptionService.cs
+++ b/Octans.Core/Subscriptions/SubscriptionService.cs
@@ -6,12 +6,20 @@ using Octans.Data.Models.Subscriptions;
 
 namespace Octans.Core.Subscriptions;
 
-public sealed class SubscriptionService(
+public interface ISubscriptionService
+{
+    Task CheckAndExecute(CancellationToken stoppingToken = default);
+    Task<List<SubscriptionStatusDto>> GetAllAsync();
+    Task AddAsync(string name, string downloaderName, string query, TimeSpan frequency);
+    Task DeleteAsync(int id);
+}
+
+internal sealed class SubscriptionService(
     IDbContextFactory<ServerDbContext> factory,
     TimeProvider timeProvider,
     IBackgroundProgressReporter reporter,
     ISubscriptionExecutor executor,
-    ILogger<SubscriptionService> logger)
+    ILogger<SubscriptionService> logger) : ISubscriptionService
 {
     public async Task CheckAndExecute(CancellationToken stoppingToken = default)
     {

--- a/Octans.Core/Tags/TagParentService.cs
+++ b/Octans.Core/Tags/TagParentService.cs
@@ -4,7 +4,7 @@ using Octans.Data.Models.Tagging;
 
 namespace Octans.Core.Tags;
 
-public class TagParentService(ServerDbContext context)
+public sealed class TagParentService(ServerDbContext context)
 {
     public async Task AddParentAsync(TagModel child, TagModel parent, CancellationToken cancellationToken = default)
     {

--- a/Octans.Core/Tags/TagService.cs
+++ b/Octans.Core/Tags/TagService.cs
@@ -3,7 +3,7 @@ using Octans.Data.Models;
 
 namespace Octans.Core.Tags;
 
-public class TagService(ServerDbContext context) : ITagService
+internal sealed class TagService(ServerDbContext context) : ITagService
 {
     public async Task<List<TagModel>> GetTagsForHashAsync(string hashHex)
     {

--- a/Octans.Core/Tags/TagSiblingService.cs
+++ b/Octans.Core/Tags/TagSiblingService.cs
@@ -5,7 +5,7 @@ namespace Octans.Core.Tags;
 
 public record ResolvedTag(TagModel Tag, TagModel Display);
 
-public class TagSiblingService(ServerDbContext context)
+public sealed class TagSiblingService(ServerDbContext context)
 {
     public async Task<IReadOnlyCollection<ResolvedTag>> Resolve(IEnumerable<TagModel> tags)
     {

--- a/Octans.Core/Tags/TagSplitter.cs
+++ b/Octans.Core/Tags/TagSplitter.cs
@@ -2,7 +2,7 @@ using Octans.Core.Querying;
 
 namespace Octans.Core.Tags;
 
-public class TagSplitter
+public sealed class TagSplitter
 {
     public (string space, string subtag) SplitTag(string tag)
     {

--- a/Octans.Core/Tags/TagUpdater.cs
+++ b/Octans.Core/Tags/TagUpdater.cs
@@ -11,7 +11,7 @@ public enum TagUpdateResult
     TagsUpdated
 }
 
-public class TagUpdater(ServerDbContext context)
+public sealed class TagUpdater(ServerDbContext context)
 {
     public async Task<TagUpdateResult> UpdateTags(UpdateTagsRequest request)
     {

--- a/Octans.Core/Thumbnails/ThumbnailCreationBackgroundService.cs
+++ b/Octans.Core/Thumbnails/ThumbnailCreationBackgroundService.cs
@@ -5,7 +5,7 @@ using Octans.Core.Progress;
 
 namespace Octans.Core.Thumbnails;
 
-public sealed class ThumbnailCreationBackgroundService(
+internal sealed class ThumbnailCreationBackgroundService(
     ThumbnailCreator creator,
     ChannelReader<ThumbnailCreationRequest> channel,
     IBackgroundProgressReporter progressReporter,

--- a/Octans.Core/Thumbnails/ThumbnailCreationRequest.cs
+++ b/Octans.Core/Thumbnails/ThumbnailCreationRequest.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Octans.Core.Thumbnails;
 
 [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "DTO")]
-public record ThumbnailCreationRequest(byte[] Bytes, ContentHash Hash)
+internal sealed record ThumbnailCreationRequest(byte[] Bytes, ContentHash Hash)
 {
     public Guid Id { get; set; } = Guid.NewGuid();
 }

--- a/Octans.Core/Thumbnails/ThumbnailCreator.cs
+++ b/Octans.Core/Thumbnails/ThumbnailCreator.cs
@@ -6,7 +6,7 @@ using SixLabors.ImageSharp.Processing;
 
 namespace Octans.Core.Thumbnails;
 
-public class ThumbnailCreator(
+internal sealed class ThumbnailCreator(
     IFileSystem fileSystem,
     ImageStorage imageStorage,
     ILogger<ThumbnailCreator> logger)

--- a/Octans.Tests/Client/Components/Subscriptions/SubscriptionsViewmodelTests.cs
+++ b/Octans.Tests/Client/Components/Subscriptions/SubscriptionsViewmodelTests.cs
@@ -19,7 +19,7 @@ namespace Octans.Tests.Client.Components.Subscriptions;
 public class SubscriptionsViewmodelTests
 {
     private readonly SubscriptionService _subscriptionService;
-    private readonly DownloaderFactory _downloaderFactory;
+    private readonly IDownloaderFactory _downloaderFactory;
     private readonly IDialogService _dialogService;
     private readonly SubscriptionsViewmodel _sut;
     private readonly ServerDbContext _dbContext;
@@ -57,10 +57,7 @@ public class SubscriptionsViewmodelTests
 
         _subscriptionService = new SubscriptionService(factory, timeProvider, reporter, executor, logger);
 
-        var fileSystem = Substitute.For<IFileSystem>();
-        var settings = Options.Create(new GlobalSettings { AppRoot = "/" });
-        var dlLogger = NullLogger<DownloaderFactory>.Instance;
-        _downloaderFactory = Substitute.For<DownloaderFactory>(fileSystem, settings, dlLogger);
+        _downloaderFactory = Substitute.For<IDownloaderFactory>();
 
         _dialogService = Substitute.For<IDialogService>();
 


### PR DESCRIPTION
## Summary

Moves Core-owned service and channel registration into `Octans.Core`, then narrows a broad set of implementation classes from public to `internal sealed` while leaving public contracts, DTOs, options, and UI-facing services available.

The client now depends on public abstractions for downloader discovery, import jobs, queries, and subscriptions where that let concrete Core implementations become internal.

## Validation

- `dotnet test`
- `git diff --check`

Note: one full `dotnet test` run initially hit a transient `DownloadTelemetryTests.RecordDownloadCompleted_EmitsHostScopedOutcomeMetrics` metric-listener assertion; the targeted test passed immediately afterward, and the full suite then passed.