### PR TITLE
[codex] Move duplicate manager behind API client

### DIFF
--- a/Octans.Client/ApiDtos.cs
+++ b/Octans.Client/ApiDtos.cs
@@ -1,3 +1,4 @@
+using Octans.Core.Downloaders;
 using Octans.Core.Importing;
 using Octans.Core.Http.Models;
 using Octans.Core.Notes;
@@ -30,6 +31,10 @@ public sealed record RepositoryTransitionRequest(
 public sealed record QuerySuggestionsDto(IReadOnlyList<TagModel> Tags);
 
 public sealed record FileQueryCountDto(int Count);
+
+public sealed record DownloadersOverviewDto(
+    string DownloaderDirectory,
+    IReadOnlyList<DownloaderMetadata> Downloaders);
 
 public sealed record SubscriptionCreateRequest(
     string Name,

--- a/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
+++ b/Octans.Client/Components/Downloads/DownloadersViewmodel.cs
@@ -2,28 +2,25 @@ using Octans.Core.Downloaders;
 
 namespace Octans.Client.Components.Downloads;
 
-public class DownloadersViewmodel
+public class DownloadersViewmodel(IOctansClient client)
 {
-    private readonly IDownloaderFactory _factory;
-
-    public DownloadersViewmodel(IDownloaderFactory factory)
-    {
-        _factory = factory;
-    }
-
     public List<DownloaderMetadata> Downloaders { get; private set; } = [];
 
-    public string DownloaderDirectory => _factory.DownloaderDirectory;
+    public string DownloaderDirectory { get; private set; } = string.Empty;
 
     public async Task Load()
     {
-        var downloaders = await _factory.GetDownloaders();
-        Downloaders = downloaders.Select(d => d.Metadata).ToList();
+        Apply(await client.GetDownloadersOverviewAsync());
     }
 
     public async Task Rescan()
     {
-        var downloaders = await _factory.Rescan();
-        Downloaders = downloaders.Select(d => d.Metadata).ToList();
+        Apply(await client.RescanDownloadersAsync());
+    }
+
+    private void Apply(DownloadersOverviewDto overview)
+    {
+        DownloaderDirectory = overview.DownloaderDirectory;
+        Downloaders = overview.Downloaders.ToList();
     }
 }

--- a/Octans.Client/Components/Downloads/Downloads.razor
+++ b/Octans.Client/Components/Downloads/Downloads.razor
@@ -1,7 +1,7 @@
 @page "/downloads"
 @inject DownloadsViewmodel Viewmodel
 @using Octans.Client.Services
-@implements IDisposable
+@implements IAsyncDisposable
 @rendermode InteractiveServer
 
 <PageTitle>Octans - Downloads</PageTitle>
@@ -38,17 +38,39 @@ else
 }
 
 @code {
+    private readonly CancellationTokenSource _polling = new();
+
     protected override async Task OnInitializedAsync()
     {
         Viewmodel.StateChanged += Refresh;
         await Viewmodel.InitializeAsync();
+        _ = Poll();
+    }
+
+    private async Task Poll()
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+
+            while (await timer.WaitForNextTickAsync(_polling.Token))
+            {
+                await InvokeAsync(() => Viewmodel.RefreshAsync(_polling.Token));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
     }
 
     private Task Refresh() => InvokeAsync(StateHasChanged);
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         Viewmodel.StateChanged -= Refresh;
-        Viewmodel.Dispose();
+        _polling.Cancel();
+        _polling.Dispose();
+
+        return ValueTask.CompletedTask;
     }
 }

--- a/Octans.Client/Components/Downloads/DownloadsViewmodel.cs
+++ b/Octans.Client/Components/Downloads/DownloadsViewmodel.cs
@@ -1,76 +1,18 @@
-using Octans.Core.Http;
-using Octans.Core.Http.Models;
-using Octans.Data.Models;
-
 namespace Octans.Client.Components.Downloads;
 
 public sealed class DownloadsViewmodel(
-    IDownloadStateService stateService) : ViewmodelBase, IDisposable
+    IOctansClient client) : ViewmodelBase
 {
-    private bool _subscribed;
-
-    public List<DownloadStatusDto> ActiveDownloads { get; private set; } = [];
+    public List<Octans.Client.DownloadStatusDto> ActiveDownloads { get; private set; } = [];
 
     public async Task InitializeAsync()
     {
-        if (!_subscribed)
-        {
-            stateService.DownloadsChanged += Handle;
-            stateService.DownloadStatusChanged += Handle;
-            _subscribed = true;
-        }
-
-        ActiveDownloads = stateService.GetAllDownloads().Select(MapStatus).ToList();
-        await Task.CompletedTask;
+        await RefreshAsync();
     }
 
-    public async ValueTask Handle(DownloadsChanged notification)
+    public async Task RefreshAsync(CancellationToken cancellationToken = default)
     {
-        ActiveDownloads = stateService.GetAllDownloads().Select(MapStatus).ToList();
+        ActiveDownloads = (await client.GetDownloadsAsync(cancellationToken)).ToList();
         await NotifyStateChanged();
     }
-
-    public async ValueTask Handle(DownloadStatusChanged notification)
-    {
-        var status = MapStatus(notification.Status);
-        var index = ActiveDownloads.FindIndex(d => d.Id == status.Id);
-        if (index >= 0)
-        {
-            ActiveDownloads[index] = status;
-        }
-        else
-        {
-            ActiveDownloads.Add(status);
-        }
-        await NotifyStateChanged();
-    }
-
-    public void Dispose()
-    {
-        if (!_subscribed) return;
-
-        stateService.DownloadsChanged -= Handle;
-        stateService.DownloadStatusChanged -= Handle;
-        _subscribed = false;
-    }
-
-    private static DownloadStatusDto MapStatus(DownloadStatus status) => new(
-        status.Id,
-        status.Domain,
-        status.DisplayName ?? status.Filename,
-        status.TotalBytes,
-        status.BytesDownloaded,
-        status.ProgressPercentage,
-        status.CurrentSpeed,
-        status.State.ToString());
 }
-
-public sealed record DownloadStatusDto(
-    Guid Id,
-    string Domain,
-    string Filename,
-    long TotalBytes,
-    long BytesDownloaded,
-    double ProgressPercentage,
-    double CurrentSpeed,
-    string State);

--- a/Octans.Client/Components/Duplicates/DuplicateManagerViewmodel.cs
+++ b/Octans.Client/Components/Duplicates/DuplicateManagerViewmodel.cs
@@ -1,14 +1,10 @@
-using Microsoft.EntityFrameworkCore;
 using MudBlazor;
-using Octans.Core.Duplicates;
-using Octans.Data.Models;
 using Octans.Data.Models.Duplicates;
 
 namespace Octans.Client.Components.Duplicates;
 
 public class DuplicateManagerViewmodel(
-    DuplicateService duplicateService,
-    ServerDbContext context,
+    IOctansClient octansClient,
     ISnackbar snackbar,
     ILogger<DuplicateManagerViewmodel> logger)
 {
@@ -26,22 +22,19 @@ public class DuplicateManagerViewmodel(
         IsLoading = true;
         try
         {
-            var candidates = await context.DuplicateCandidates
-                .Include(c => c.Hash1)
-                .Include(c => c.Hash2)
+            var candidates = await octansClient.GetDuplicateCandidatesAsync();
+
+            Candidates = candidates
                 .OrderByDescending(c => c.Distance)
                 .Take(50)
-                .ToListAsync();
-
-            Candidates = candidates.Select(c => new DuplicateCandidateDto
+                .Select(c => new DuplicateCandidateDto
             {
                 Id = c.Id,
                 HashId1 = c.HashId1,
                 HashId2 = c.HashId2,
                 Distance = c.Distance,
-                // Url logic might need adjustment based on how we serve images
-                Url1 = $"/api/files/{Convert.ToHexString(c.Hash1.Hash)}",
-                Url2 = $"/api/files/{Convert.ToHexString(c.Hash2.Hash)}"
+                Url1 = c.MediaUrl1,
+                Url2 = c.MediaUrl2
             }).ToList();
         }
         catch (Exception ex)
@@ -60,11 +53,7 @@ public class DuplicateManagerViewmodel(
         IsCalculating = true;
         try
         {
-            await Task.Run(async () =>
-            {
-                await duplicateService.CalculateMissingHashes();
-                await duplicateService.FindDuplicates();
-            });
+            await octansClient.ScanDuplicatesAsync();
             await LoadCandidates();
             snackbar.Add("Check complete", Severity.Success);
         }
@@ -83,23 +72,8 @@ public class DuplicateManagerViewmodel(
     {
         try
         {
-            await duplicateService.Resolve(candidateId, MapResolution(resolution), keepHashId);
-
-            // Remove from local list
-            var candidate = Candidates.FirstOrDefault(c => c.Id == candidateId);
-            if (candidate != null)
-            {
-                Candidates.Remove(candidate);
-
-                // If we deleted one, we should also remove any other candidates involving the deleted hash?
-                // The service handles data integrity, but UI might show stale data.
-                // We'll just reload or remove locally.
-                if (keepHashId.HasValue)
-                {
-                    var deletedId = candidate.HashId1 == keepHashId ? candidate.HashId2 : candidate.HashId1;
-                    Candidates.RemoveAll(c => c.HashId1 == deletedId || c.HashId2 == deletedId);
-                }
-            }
+            await octansClient.ResolveDuplicateCandidateAsync(candidateId, MapResolution(resolution), keepHashId);
+            await LoadCandidates();
         }
         catch (Exception ex)
         {

--- a/Octans.Client/Components/Gallery/DetailsPaneViewmodel.cs
+++ b/Octans.Client/Components/Gallery/DetailsPaneViewmodel.cs
@@ -1,16 +1,12 @@
-using System.Threading.Channels;
 using MudBlazor;
 using Octans.Core.Notes;
 using Octans.Core.Repositories;
-using Octans.Core.Tags;
 
 namespace Octans.Client.Components.Gallery;
 
 public sealed class DetailsPaneViewmodel(
-    INoteService noteService,
-    ITagService tagService,
     ISnackbar snackbar,
-    ChannelWriter<RepositoryChangeRequest> repositoryChannel) : ViewmodelBase
+    IOctansClient client) : ViewmodelBase
 {
     public string? SelectedHash { get; private set; }
     public List<NoteDto> Notes { get; private set; } = [];
@@ -33,7 +29,7 @@ public sealed class DetailsPaneViewmodel(
             return;
         }
 
-        await repositoryChannel.WriteAsync(new(SelectedHash, RepositoryDestination.Archive));
+        await client.TransitionRepositoryItemsAsync([SelectedHash], RepositoryDestination.Archive);
         snackbar.Add("Archived", Severity.Success);
     }
 
@@ -44,7 +40,7 @@ public sealed class DetailsPaneViewmodel(
             return;
         }
 
-        await repositoryChannel.WriteAsync(new(SelectedHash, RepositoryDestination.Inbox));
+        await client.TransitionRepositoryItemsAsync([SelectedHash], RepositoryDestination.Inbox);
         snackbar.Add("Moved to Inbox", Severity.Success);
     }
 
@@ -57,7 +53,7 @@ public sealed class DetailsPaneViewmodel(
 
         try
         {
-            var note = await noteService.AddNoteAsync(SelectedHash, NewNoteContent);
+            var note = await client.AddNoteAsync(SelectedHash, NewNoteContent);
             Notes.Add(note);
             NewNoteContent = string.Empty;
             snackbar.Add("Note added", Severity.Success);
@@ -73,7 +69,7 @@ public sealed class DetailsPaneViewmodel(
     {
         try
         {
-            await noteService.DeleteNoteAsync(note.Id);
+            await client.DeleteNoteAsync(note.Id);
             Notes.Remove(note);
             snackbar.Add("Note deleted", Severity.Success);
             await NotifyStateChanged();
@@ -94,8 +90,8 @@ public sealed class DetailsPaneViewmodel(
             return;
         }
 
-        Notes = await noteService.GetNotesAsync(SelectedHash);
-        var tagModels = await tagService.GetTagsForHashAsync(SelectedHash);
-        Tags = tagModels.Select(t => new TagViewer.Tag(t.Namespace, t.Subtag, 0)).ToList();
+        var details = await client.GetMediaDetailsAsync(SelectedHash);
+        Notes = details?.Notes.ToList() ?? [];
+        Tags = details?.Tags.Select(t => new TagViewer.Tag(t.Namespace, t.Subtag, 0)).ToList() ?? [];
     }
 }

--- a/Octans.Client/Components/Gallery/GalleryViewmodel.cs
+++ b/Octans.Client/Components/Gallery/GalleryViewmodel.cs
@@ -1,4 +1,3 @@
-using System.Threading.Channels;
 using MudBlazor;
 using Octans.Client.Components.StatusBar;
 using Octans.Client.Services;
@@ -18,12 +17,11 @@ public record GalleryContextMenuItem(
 };
 
 public sealed class GalleryViewmodel(
-    IQueryService service,
+    IOctansClient client,
     IBrowserStorage storage,
     IClipboardService clipboard,
     StatusService status,
     ICustomCommandProvider customCommandProvider,
-    ChannelWriter<RepositoryChangeRequest> repositoryChannel,
     IBrowserService browserService,
     ILogger<GalleryViewmodel> logger) : ViewmodelBase, IAsyncDisposable
 {
@@ -138,8 +136,7 @@ public sealed class GalleryViewmodel(
         {
             try
             {
-                var hex = url[(url.LastIndexOf('/') + 1)..];
-                await repositoryChannel.WriteAsync(new(hex, RepositoryDestination.Archive));
+                await client.TransitionRepositoryItemsAsync([GetHashFromUrl(url)], RepositoryDestination.Archive);
             }
             catch (Exception e)
             {
@@ -156,8 +153,7 @@ public sealed class GalleryViewmodel(
         {
             try
             {
-                var hex = url[(url.LastIndexOf('/') + 1)..];
-                await repositoryChannel.WriteAsync(new(hex, RepositoryDestination.Inbox));
+                await client.TransitionRepositoryItemsAsync([GetHashFromUrl(url)], RepositoryDestination.Inbox);
             }
             catch (Exception e)
             {
@@ -174,8 +170,7 @@ public sealed class GalleryViewmodel(
         {
             try
             {
-                var hex = url[(url.LastIndexOf('/') + 1)..];
-                await repositoryChannel.WriteAsync(new(hex, RepositoryDestination.Trash));
+                await client.TransitionRepositoryItemsAsync([GetHashFromUrl(url)], RepositoryDestination.Trash);
                 ImageUrls.Remove(url);
             }
             catch (Exception e)
@@ -204,9 +199,9 @@ public sealed class GalleryViewmodel(
                 .Select(s => s.Raw)
                 .ToList();
 
-            _total = await service.CountAsync(raw, _cts.Token);
+            _total = await client.CountQueryFilesAsync(raw, _cts.Token);
 
-            await foreach (var result in service.Query(raw, _cts.Token))
+            foreach (var result in await client.QueryFilesAsync(raw, _cts.Token))
             {
                 // Build a stable, lower-case hex string for the route
                 var hex = Convert
@@ -278,8 +273,6 @@ public sealed class GalleryViewmodel(
     {
         foreach ((var url, var choice) in result.Choices)
         {
-            var hex = url[(url.LastIndexOf('/') + 1)..];
-
             var destination = choice switch
             {
                 ImageViewerFilterChoice.Archive => RepositoryDestination.Archive,
@@ -287,7 +280,7 @@ public sealed class GalleryViewmodel(
                 _ => RepositoryDestination.Inbox
             };
 
-            await repositoryChannel.WriteAsync(new(hex, destination));
+            await client.TransitionRepositoryItemsAsync([GetHashFromUrl(url)], destination);
         }
 
         ImageUrls.RemoveAll(url =>
@@ -303,4 +296,6 @@ public sealed class GalleryViewmodel(
         await _cts.CancelAsync();
         _cts.Dispose();
     }
+
+    private static string GetHashFromUrl(string url) => url[(url.LastIndexOf('/') + 1)..];
 }

--- a/Octans.Client/Components/Gallery/ImageViewerViewmodel.cs
+++ b/Octans.Client/Components/Gallery/ImageViewerViewmodel.cs
@@ -7,7 +7,7 @@ using Octans.Core.Tags;
 namespace Octans.Client.Components.Gallery;
 
 public sealed class ImageViewerViewmodel(
-    ITagService tagService,
+    IOctansClient client,
     IKeybindingService keybindingService) : ViewmodelBase
 {
     private readonly Dictionary<string, ImageViewerFilterChoice> _choices = [];
@@ -165,7 +165,8 @@ public sealed class ImageViewerViewmodel(
 
         try
         {
-            Tags = await tagService.GetTagsForHashAsync(GetHashFromMediaUrl(CurrentImage));
+            var details = await client.GetMediaDetailsAsync(GetHashFromMediaUrl(CurrentImage));
+            Tags = details?.Tags.ToList() ?? [];
         }
         catch (Exception)
         {

--- a/Octans.Client/Components/Gallery/QueryBuilderViewmodel.cs
+++ b/Octans.Client/Components/Gallery/QueryBuilderViewmodel.cs
@@ -1,9 +1,9 @@
 using Octans.Core.Querying;
-using DataTag = Octans.Data.Models.Tagging.Tag;
+using Octans.Core.Tags;
 
 namespace Octans.Client.Components.Gallery;
 
-public sealed class QueryBuilderViewmodel(QuerySuggestionFinder suggestionFinder) : ViewmodelBase, IDisposable
+public sealed class QueryBuilderViewmodel(IOctansClient client) : ViewmodelBase, IDisposable
 {
     private CancellationTokenSource? _debounceCts;
     private CancellationTokenSource? _requestCts;
@@ -119,7 +119,7 @@ public sealed class QueryBuilderViewmodel(QuerySuggestionFinder suggestionFinder
 
         try
         {
-            var results = await suggestionFinder.GetAutocompleteTagIds(term, false, _requestCts.Token);
+            var results = await client.GetQuerySuggestionsAsync(term, cancellationToken: _requestCts.Token);
 
             _suggestions.Clear();
 
@@ -172,9 +172,7 @@ public sealed class QueryBuilderViewmodel(QuerySuggestionFinder suggestionFinder
         await AddCurrentAsync();
     }
 
-    private static QuerySuggestionDto MapSuggestion(DataTag tag) => new(
-        tag.Namespace.Value,
-        tag.Subtag.Value);
+    private static QuerySuggestionDto MapSuggestion(TagModel tag) => new(tag.Namespace, tag.Subtag);
 
     private async Task NotifyQueryChangedAsync()
     {

--- a/Octans.Client/Components/Importing/ImportJobsPanel.razor
+++ b/Octans.Client/Components/Importing/ImportJobsPanel.razor
@@ -1,6 +1,6 @@
 @implements IAsyncDisposable
 @using Octans.Core.Importing
-@inject IImportJobService ImportJobService
+@inject IOctansClient Client
 
 <section class="import-jobs-panel">
     <div class="import-jobs-header">
@@ -89,25 +89,25 @@
 
     private async Task Refresh()
     {
-        _jobs = await ImportJobService.GetJobs(_polling.Token);
+        _jobs = await Client.GetImportJobsAsync(_polling.Token);
         StateHasChanged();
     }
 
     private async Task Pause(Guid id)
     {
-        await ImportJobService.PauseJob(id, _polling.Token);
+        await Client.PauseImportJobAsync(id, _polling.Token);
         await Refresh();
     }
 
     private async Task Resume(Guid id)
     {
-        await ImportJobService.ResumeJob(id, _polling.Token);
+        await Client.ResumeImportJobAsync(id, _polling.Token);
         await Refresh();
     }
 
     private async Task Cancel(Guid id)
     {
-        await ImportJobService.CancelJob(id, _polling.Token);
+        await Client.CancelImportJobAsync(id, _polling.Token);
         await Refresh();
     }
 

--- a/Octans.Client/Components/Importing/ImportsViewmodel.cs
+++ b/Octans.Client/Components/Importing/ImportsViewmodel.cs
@@ -26,7 +26,7 @@ public interface ILocalFileImportViewmodel
 public class LocalFileImportViewmodel(
     IFileSystem fileSystem,
     IWebHostEnvironment environment,
-    IImportJobService importJobService,
+    IOctansClient client,
     ILogger<LocalFileImportViewmodel> logger) : ILocalFileImportViewmodel
 {
     public IReadOnlyList<IBrowserFile> LocalFiles { get; set; } = [];
@@ -76,7 +76,7 @@ public class LocalFileImportViewmodel(
             AutoArchive = AutoArchive
         };
 
-        var created = await importJobService.Create(new()
+        var created = await client.CreateImportJobAsync(new()
         {
             ImportType = request.ImportType,
             Sources = sources,
@@ -92,7 +92,7 @@ public class LocalFileImportViewmodel(
 }
 
 public class RawUrlImportViewmodel(
-    IImportJobService importJobService,
+    IOctansClient client,
     ILogger<RawUrlImportViewmodel> logger) : IRawUrlImportViewmodel
 {
     public string RawInputs { get; set; } = string.Empty;
@@ -139,7 +139,7 @@ public class RawUrlImportViewmodel(
                 AutoArchive = AutoArchive
             };
 
-            var created = await importJobService.Create(new()
+            var created = await client.CreateImportJobAsync(new()
             {
                 ImportType = request.ImportType,
                 Sources = urls,

--- a/Octans.Client/Components/Subscriptions/SubscriptionsViewmodel.cs
+++ b/Octans.Client/Components/Subscriptions/SubscriptionsViewmodel.cs
@@ -1,12 +1,10 @@
 using MudBlazor;
-using Octans.Core.Downloaders;
 using Octans.Core.Subscriptions;
 
 namespace Octans.Client.Components.Subscriptions;
 
 public class SubscriptionsViewmodel(
-    ISubscriptionService subscriptionService,
-    IDownloaderFactory downloaderFactory,
+    IOctansClient client,
     IDialogService dialogService)
 {
     public List<SubscriptionStatusDto> Subscriptions { get; private set; } = [];
@@ -18,13 +16,13 @@ public class SubscriptionsViewmodel(
 
     private async Task LoadSubscriptionsAsync()
     {
-        Subscriptions = await subscriptionService.GetAllAsync();
+        Subscriptions = (await client.GetSubscriptionsAsync()).ToList();
     }
 
     public async Task AddSubscriptionAsync()
     {
-        var downloaders = await downloaderFactory.GetDownloaders();
-        var downloaderNames = downloaders.Select(d => d.Metadata.Name).OrderBy(n => n).ToList();
+        var downloaders = await client.GetDownloadersAsync();
+        var downloaderNames = downloaders.Select(d => d.Name).OrderBy(n => n).ToList();
 
         var parameters = new DialogParameters<AddSubscriptionDialog>
         {
@@ -36,18 +34,18 @@ public class SubscriptionsViewmodel(
 
         if (result is not null && !result.Canceled && result.Data is AddSubscriptionDialog.FormModel model)
         {
-            await subscriptionService.AddAsync(
+            await client.AddSubscriptionAsync(new(
                 model.Name,
                 model.Downloader,
                 model.Query,
-                TimeSpan.FromMinutes(model.FrequencyMinutes));
+                model.FrequencyMinutes));
             await LoadSubscriptionsAsync();
         }
     }
 
     public async Task DeleteSubscriptionAsync(int id)
     {
-        await subscriptionService.DeleteAsync(id);
+        await client.DeleteSubscriptionAsync(id);
         await LoadSubscriptionsAsync();
     }
 }

--- a/Octans.Client/Endpoints.cs
+++ b/Octans.Client/Endpoints.cs
@@ -95,6 +95,17 @@ internal static class Endpoints
 
     private static void MapDownloaderEndpoints(WebApplication app)
     {
+        app.MapGet("/downloaders/overview",
+            async ([FromServices] IDownloaderFactory ds) =>
+            {
+                var downloaders = await ds.GetDownloaders();
+
+                return new DownloadersOverviewDto(
+                    ds.DownloaderDirectory,
+                    downloaders.Select(d => d.Metadata).ToList());
+            })
+            .WithName("GetDownloadersOverview");
+
         app.MapGet("/downloaders",
             async ([FromServices] IDownloaderFactory ds) =>
             {
@@ -112,6 +123,17 @@ internal static class Endpoints
 
                 return downloader;
             });
+
+        app.MapPost("/downloaders/rescan",
+            async ([FromServices] IDownloaderFactory ds) =>
+            {
+                var downloaders = await ds.Rescan();
+
+                return new DownloadersOverviewDto(
+                    ds.DownloaderDirectory,
+                    downloaders.Select(d => d.Metadata).ToList());
+            })
+            .WithName("RescanDownloaders");
     }
 
     private static void MapFileEndpoints(WebApplication app)

--- a/Octans.Client/OctansClient.cs
+++ b/Octans.Client/OctansClient.cs
@@ -6,8 +6,12 @@ using System.Text.Json.Serialization;
 using Octans.Core;
 using Octans.Core.Downloaders;
 using Octans.Core.Filesystem;
+using Octans.Core.Http.Models;
 using Octans.Core.Importing;
+using Octans.Core.Notes;
+using Octans.Core.Repositories;
 using Octans.Core.Stats;
+using Octans.Core.Subscriptions;
 using Octans.Core.Tags;
 using Octans.Data.Models;
 using Octans.Data.Models.Duplicates;
@@ -19,11 +23,38 @@ public interface IOctansClient
     Task<IReadOnlyList<HashItem>> GetFilesAsync(CancellationToken cancellationToken = default);
     Task<string?> GetFileAsync(int id, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<HashItem>> QueryFilesAsync(IEnumerable<string> queries, CancellationToken cancellationToken = default);
+    Task<int> CountQueryFilesAsync(IEnumerable<string> queries, CancellationToken cancellationToken = default);
+    Task<MediaDetailsDto?> GetMediaDetailsAsync(string hash, CancellationToken cancellationToken = default);
+    Task<NoteDto> AddNoteAsync(string hash, string content, CancellationToken cancellationToken = default);
+    Task UpdateNoteAsync(int id, string content, CancellationToken cancellationToken = default);
+    Task DeleteNoteAsync(int id, CancellationToken cancellationToken = default);
+    Task TransitionRepositoryItemsAsync(
+        IEnumerable<string> hashes,
+        RepositoryDestination destination,
+        CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<TagModel>> GetQuerySuggestionsAsync(
+        string search,
+        bool exact = false,
+        CancellationToken cancellationToken = default);
     Task<ImportJobClientResult> ImportFilesAsync(ImportRequest request, CancellationToken cancellationToken = default);
+    Task<ImportJobClientResult> CreateImportJobAsync(
+        ImportJobCreateRequest request,
+        CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ImportJobDto>> GetImportJobsAsync(CancellationToken cancellationToken = default);
+    Task<ImportJobDto?> GetImportJobAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ImportJobDto?> PauseImportJobAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ImportJobDto?> ResumeImportJobAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ImportJobDto?> CancelImportJobAsync(Guid id, CancellationToken cancellationToken = default);
     Task<bool> UpdateTagsAsync(UpdateTagsRequest request, CancellationToken cancellationToken = default);
     Task<DeleteResponse> DeleteFilesAsync(DeleteRequest request, CancellationToken cancellationToken = default);
     Task<DeleteResponse> DeleteFilesAsync(IEnumerable<int> ids, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<DownloaderMetadata>> GetDownloadersAsync(CancellationToken cancellationToken = default);
+    Task<DownloadersOverviewDto> GetDownloadersOverviewAsync(CancellationToken cancellationToken = default);
+    Task<DownloadersOverviewDto> RescanDownloadersAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SubscriptionStatusDto>> GetSubscriptionsAsync(CancellationToken cancellationToken = default);
+    Task AddSubscriptionAsync(SubscriptionCreateRequest request, CancellationToken cancellationToken = default);
+    Task DeleteSubscriptionAsync(int id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<DownloadStatusDto>> GetDownloadsAsync(CancellationToken cancellationToken = default);
     Task<HomeStats> GetHomeStatsAsync(CancellationToken cancellationToken = default);
     Task<OctansVersion> GetVersionAsync(CancellationToken cancellationToken = default);
     Task<DuplicateScanResultDto> ScanDuplicatesAsync(CancellationToken cancellationToken = default);
@@ -87,6 +118,95 @@ public sealed class OctansClient(HttpClient httpClient) : IOctansClient
         return files ?? [];
     }
 
+    public async Task<int> CountQueryFilesAsync(
+        IEnumerable<string> queries,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsJsonAsync("files/query/count", queries, JsonOptions, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        var count = await ReadRequiredJsonAsync<FileQueryCountDto>(response, cancellationToken);
+
+        return count.Count;
+    }
+
+    public async Task<MediaDetailsDto?> GetMediaDetailsAsync(
+        string hash,
+        CancellationToken cancellationToken = default)
+    {
+        var uri = new Uri($"media/{hash}/details", UriKind.Relative);
+        using var response = await httpClient.GetAsync(uri, cancellationToken);
+
+        if (response.StatusCode is HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        return await ReadRequiredJsonAsync<MediaDetailsDto>(response, cancellationToken);
+    }
+
+    public async Task<NoteDto> AddNoteAsync(
+        string hash,
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsJsonAsync(
+            $"media/{hash}/notes",
+            new NoteCreateRequest(content),
+            JsonOptions,
+            cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        return await ReadRequiredJsonAsync<NoteDto>(response, cancellationToken);
+    }
+
+    public async Task UpdateNoteAsync(
+        int id,
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PutAsJsonAsync(
+            $"notes/{id.ToString(CultureInfo.InvariantCulture)}",
+            new NoteUpdateRequest(content),
+            JsonOptions,
+            cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+    }
+
+    public async Task DeleteNoteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var uri = new Uri($"notes/{id.ToString(CultureInfo.InvariantCulture)}", UriKind.Relative);
+        using var response = await httpClient.DeleteAsync(uri, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+    }
+
+    public async Task TransitionRepositoryItemsAsync(
+        IEnumerable<string> hashes,
+        RepositoryDestination destination,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new RepositoryTransitionRequest(hashes.ToList(), destination);
+        using var response = await httpClient.PostAsJsonAsync(
+            "repository/transitions",
+            request,
+            JsonOptions,
+            cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<TagModel>> GetQuerySuggestionsAsync(
+        string search,
+        bool exact = false,
+        CancellationToken cancellationToken = default)
+    {
+        var uri = $"tags/suggestions?search={Uri.EscapeDataString(search)}&exact={exact.ToString().ToLowerInvariant()}";
+        var response = await httpClient.GetFromJsonAsync<QuerySuggestionsDto>(uri, JsonOptions, cancellationToken);
+
+        return response?.Tags ?? [];
+    }
+
     public async Task<ImportJobClientResult> ImportFilesAsync(
         ImportRequest request,
         CancellationToken cancellationToken = default)
@@ -98,6 +218,52 @@ public sealed class OctansClient(HttpClient httpClient) : IOctansClient
 
         return new(created.JobId, $"/import-jobs/{created.JobId}");
     }
+
+    public async Task<ImportJobClientResult> CreateImportJobAsync(
+        ImportJobCreateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsJsonAsync("import-jobs", request, JsonOptions, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        var created = await ReadRequiredJsonAsync<ImportJobCreatedDto>(response, cancellationToken);
+
+        return new(created.JobId, $"/import-jobs/{created.JobId}");
+    }
+
+    public async Task<IReadOnlyList<ImportJobDto>> GetImportJobsAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetFromJsonAsync<List<ImportJobDto>>(
+            "import-jobs",
+            JsonOptions,
+            cancellationToken);
+
+        return response ?? [];
+    }
+
+    public async Task<ImportJobDto?> GetImportJobAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var uri = new Uri($"import-jobs/{id}", UriKind.Relative);
+        using var response = await httpClient.GetAsync(uri, cancellationToken);
+
+        if (response.StatusCode is HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        return await ReadRequiredJsonAsync<ImportJobDto>(response, cancellationToken);
+    }
+
+    public Task<ImportJobDto?> PauseImportJobAsync(Guid id, CancellationToken cancellationToken = default) =>
+        TransitionImportJobAsync(id, "pause", cancellationToken);
+
+    public Task<ImportJobDto?> ResumeImportJobAsync(Guid id, CancellationToken cancellationToken = default) =>
+        TransitionImportJobAsync(id, "resume", cancellationToken);
+
+    public Task<ImportJobDto?> CancelImportJobAsync(Guid id, CancellationToken cancellationToken = default) =>
+        TransitionImportJobAsync(id, "cancel", cancellationToken);
 
     public async Task<bool> UpdateTagsAsync(UpdateTagsRequest request, CancellationToken cancellationToken = default)
     {
@@ -132,6 +298,54 @@ public sealed class OctansClient(HttpClient httpClient) : IOctansClient
     {
         var response = await httpClient.GetFromJsonAsync<List<DownloaderMetadata>>(
             "downloaders",
+            JsonOptions,
+            cancellationToken);
+
+        return response ?? [];
+    }
+
+    public async Task<DownloadersOverviewDto> GetDownloadersOverviewAsync(CancellationToken cancellationToken = default)
+    {
+        return await ReadRequiredJsonAsync<DownloadersOverviewDto>("downloaders/overview", cancellationToken);
+    }
+
+    public async Task<DownloadersOverviewDto> RescanDownloadersAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsync(new Uri("downloaders/rescan", UriKind.Relative), null, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        return await ReadRequiredJsonAsync<DownloadersOverviewDto>(response, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SubscriptionStatusDto>> GetSubscriptionsAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetFromJsonAsync<List<SubscriptionStatusDto>>(
+            "subscriptions",
+            JsonOptions,
+            cancellationToken);
+
+        return response ?? [];
+    }
+
+    public async Task AddSubscriptionAsync(
+        SubscriptionCreateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsJsonAsync("subscriptions", request, JsonOptions, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+    }
+
+    public async Task DeleteSubscriptionAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var uri = new Uri($"subscriptions/{id.ToString(CultureInfo.InvariantCulture)}", UriKind.Relative);
+        using var response = await httpClient.DeleteAsync(uri, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<DownloadStatusDto>> GetDownloadsAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetFromJsonAsync<List<DownloadStatusDto>>(
+            "downloads",
             JsonOptions,
             cancellationToken);
 
@@ -227,6 +441,24 @@ public sealed class OctansClient(HttpClient httpClient) : IOctansClient
         var content = await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken);
 
         return content ?? throw new InvalidOperationException($"Octans API returned an empty {typeof(T).Name} response.");
+    }
+
+    private async Task<ImportJobDto?> TransitionImportJobAsync(
+        Guid id,
+        string transition,
+        CancellationToken cancellationToken)
+    {
+        var uri = new Uri($"import-jobs/{id}/{transition}", UriKind.Relative);
+        using var response = await httpClient.PostAsync(uri, null, cancellationToken);
+
+        if (response.StatusCode is HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        return await ReadRequiredJsonAsync<ImportJobDto>(response, cancellationToken);
     }
 }
 

--- a/Octans.Client/OctansClient.cs
+++ b/Octans.Client/OctansClient.cs
@@ -10,6 +10,7 @@ using Octans.Core.Importing;
 using Octans.Core.Stats;
 using Octans.Core.Tags;
 using Octans.Data.Models;
+using Octans.Data.Models.Duplicates;
 
 namespace Octans.Client;
 
@@ -25,6 +26,14 @@ public interface IOctansClient
     Task<IReadOnlyList<DownloaderMetadata>> GetDownloadersAsync(CancellationToken cancellationToken = default);
     Task<HomeStats> GetHomeStatsAsync(CancellationToken cancellationToken = default);
     Task<OctansVersion> GetVersionAsync(CancellationToken cancellationToken = default);
+    Task<DuplicateScanResultDto> ScanDuplicatesAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<DuplicateCandidateDto>> GetDuplicateCandidatesAsync(
+        CancellationToken cancellationToken = default);
+    Task ResolveDuplicateCandidateAsync(
+        int candidateId,
+        DuplicateResolution resolution,
+        int? keepHashId,
+        CancellationToken cancellationToken = default);
     Task ClearAllDataAsync(CancellationToken cancellationToken = default);
     string GetMediaUrl(ContentHash hash);
     string GetMediaUrl(string hexHash);
@@ -33,6 +42,7 @@ public interface IOctansClient
 public sealed class OctansClient(HttpClient httpClient) : IOctansClient
 {
     private static readonly Uri ClearAllDataUri = new("clearAllData", UriKind.Relative);
+    private static readonly Uri DuplicateScanUri = new("duplicates/scan", UriKind.Relative);
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -136,6 +146,38 @@ public sealed class OctansClient(HttpClient httpClient) : IOctansClient
     public async Task<OctansVersion> GetVersionAsync(CancellationToken cancellationToken = default)
     {
         return await ReadRequiredJsonAsync<OctansVersion>("version", cancellationToken);
+    }
+
+    public async Task<DuplicateScanResultDto> ScanDuplicatesAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsync(DuplicateScanUri, null, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
+
+        return await ReadRequiredJsonAsync<DuplicateScanResultDto>(response, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<DuplicateCandidateDto>> GetDuplicateCandidatesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetFromJsonAsync<List<DuplicateCandidateDto>>(
+            "duplicates/candidates",
+            JsonOptions,
+            cancellationToken);
+
+        return response ?? [];
+    }
+
+    public async Task ResolveDuplicateCandidateAsync(
+        int candidateId,
+        DuplicateResolution resolution,
+        int? keepHashId,
+        CancellationToken cancellationToken = default)
+    {
+        var uri = $"duplicates/candidates/{candidateId.ToString(CultureInfo.InvariantCulture)}/resolution";
+        var request = new DuplicateResolutionRequest(resolution, keepHashId);
+
+        using var response = await httpClient.PostAsJsonAsync(uri, request, JsonOptions, cancellationToken);
+        await EnsureSuccessAsync(response, cancellationToken);
     }
 
     public async Task ClearAllDataAsync(CancellationToken cancellationToken = default)

--- a/Octans.Tests/Client/Components/Subscriptions/SubscriptionsViewmodelTests.cs
+++ b/Octans.Tests/Client/Components/Subscriptions/SubscriptionsViewmodelTests.cs
@@ -1,101 +1,43 @@
-using System.IO.Abstractions;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using MudBlazor;
 using NSubstitute;
+using Octans.Client;
 using Octans.Client.Components.Subscriptions;
-using Octans.Core;
 using Octans.Core.Downloaders;
-using Octans.Core.Progress;
 using Octans.Core.Subscriptions;
-using Octans.Data.Models;
-using Octans.Data.Models.Subscriptions;
 using Octans.Tests.Helpers;
 
 namespace Octans.Tests.Client.Components.Subscriptions;
 
 public class SubscriptionsViewmodelTests
 {
-    private readonly SubscriptionService _subscriptionService;
-    private readonly IDownloaderFactory _downloaderFactory;
-    private readonly IDialogService _dialogService;
+    private readonly IOctansClient _client = Substitute.For<IOctansClient>();
+    private readonly IDialogService _dialogService = Substitute.For<IDialogService>();
     private readonly SubscriptionsViewmodel _sut;
-    private readonly ServerDbContext _dbContext;
 
     public SubscriptionsViewmodelTests()
     {
-        var connection = new Microsoft.Data.Sqlite.SqliteConnection("DataSource=:memory:");
-        connection.Open();
-
-        var options = new DbContextOptionsBuilder<ServerDbContext>()
-            .UseSqlite(connection)
-            .Options;
-        _dbContext = new ServerDbContext(options);
-        _dbContext.Database.EnsureCreated();
-
-        // Create a new context for each factory call to simulate scope
-        var factory = Substitute.For<IDbContextFactory<ServerDbContext>>();
-        factory.CreateDbContextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
-        {
-            var ctx = new ServerDbContext(options);
-            return ctx;
-        });
-        factory.CreateDbContextAsync().Returns(_ =>
-        {
-            var ctx = new ServerDbContext(options);
-            return ctx;
-        });
-
-        var timeProvider = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
-        timeProvider.SetUtcNow(TestClock.UtcNow);
-
-        var reporter = Substitute.For<IBackgroundProgressReporter>();
-        var executor = Substitute.For<ISubscriptionExecutor>();
-        var logger = NullLogger<SubscriptionService>.Instance;
-
-        _subscriptionService = new SubscriptionService(factory, timeProvider, reporter, executor, logger);
-
-        _downloaderFactory = Substitute.For<IDownloaderFactory>();
-
-        _dialogService = Substitute.For<IDialogService>();
-
-        _sut = new SubscriptionsViewmodel(_subscriptionService, _downloaderFactory, _dialogService);
+        _sut = new(_client, _dialogService);
     }
 
     [Fact]
     public async Task InitializeAsync_ShouldLoadSubscriptions()
     {
-        // Arrange
-        var provider = new Provider { Name = "TestDownloader" };
-        _dbContext.Providers.Add(provider);
-        _dbContext.Subscriptions.Add(new Subscription
-        {
-            Name = "TestSub",
-            Provider = provider,
-            Query = "TestQuery",
-            CheckPeriod = TimeSpan.FromMinutes(60),
-            NextCheck = TestClock.UtcNow
-        });
-        await _dbContext.SaveChangesAsync();
+        var subscription = CreateSubscription();
+        _client.GetSubscriptionsAsync().Returns([subscription]);
 
-        // Act
         await _sut.InitializeAsync();
 
-        // Assert
-        _sut.Subscriptions.Should().HaveCount(1);
-        _sut.Subscriptions[0].Name.Should().Be("TestSub");
-        _sut.Subscriptions[0].DownloaderName.Should().Be("TestDownloader");
+        _sut.Subscriptions.Should().ContainSingle().Which.Should().Be(subscription);
     }
 
     [Fact]
     public async Task AddSubscriptionAsync_ShouldAddSubscription_WhenDialogConfirmed()
     {
-        // Arrange
-        _downloaderFactory.GetDownloaders().Returns(Task.FromResult(new List<Downloader>()));
+        _client.GetDownloadersAsync().Returns([new DownloaderMetadata { Name = "TestDownloader" }]);
+        _client.GetSubscriptionsAsync().Returns(
+            [CreateSubscription(name: "NewSub", downloaderName: "TestDownloader", query: "NewQuery")]);
 
-        // Mock DialogService to return result
         var dialogReference = Substitute.For<IDialogReference>();
         var formModel = new AddSubscriptionDialog.FormModel
         {
@@ -104,41 +46,49 @@ public class SubscriptionsViewmodelTests
             Query = "NewQuery",
             FrequencyMinutes = 30
         };
-        var dialogResult = DialogResult.Ok(formModel);
-        dialogReference.Result.Returns(Task.FromResult<DialogResult?>(dialogResult));
-        _dialogService.ShowAsync<AddSubscriptionDialog>(Arg.Any<string>(), Arg.Any<DialogParameters<AddSubscriptionDialog>>())
+        dialogReference.Result.Returns(Task.FromResult<DialogResult?>(DialogResult.Ok(formModel)));
+        _dialogService.ShowAsync<AddSubscriptionDialog>(
+                Arg.Any<string>(),
+                Arg.Any<DialogParameters<AddSubscriptionDialog>>())
             .Returns(Task.FromResult(dialogReference));
 
-        // Act
         await _sut.AddSubscriptionAsync();
 
-        // Assert
-        _dbContext.Subscriptions.Should().ContainSingle(s => s.Name == "NewSub" && s.Query == "NewQuery");
+        await _client
+            .Received(1)
+            .AddSubscriptionAsync(Arg.Is<SubscriptionCreateRequest>(r =>
+                r.Name == "NewSub"
+                && r.DownloaderName == "TestDownloader"
+                && r.Query == "NewQuery"
+                && r.FrequencyMinutes == 30));
         _sut.Subscriptions.Should().ContainSingle(s => s.Name == "NewSub");
     }
 
     [Fact]
     public async Task DeleteSubscriptionAsync_ShouldRemoveSubscription()
     {
-        // Arrange
-        var provider = new Provider { Name = "TestDownloader" };
-        _dbContext.Providers.Add(provider);
-        var sub = new Subscription
-        {
-            Name = "TestSub",
-            Provider = provider,
-            Query = "TestQuery",
-            CheckPeriod = TimeSpan.FromMinutes(60),
-            NextCheck = TestClock.UtcNow
-        };
-        _dbContext.Subscriptions.Add(sub);
-        await _dbContext.SaveChangesAsync();
+        _client.GetSubscriptionsAsync().Returns([CreateSubscription()]);
 
-        // Act
-        await _sut.DeleteSubscriptionAsync(sub.Id);
+        await _sut.InitializeAsync();
+        _client.GetSubscriptionsAsync().Returns([]);
+        await _sut.DeleteSubscriptionAsync(7);
 
-        // Assert
-        _dbContext.Subscriptions.Should().BeEmpty();
+        await _client.Received(1).DeleteSubscriptionAsync(7);
         _sut.Subscriptions.Should().BeEmpty();
     }
+
+    private static SubscriptionStatusDto CreateSubscription(
+        int id = 7,
+        string name = "TestSub",
+        string downloaderName = "TestDownloader",
+        string query = "TestQuery") =>
+        new(
+            id,
+            name,
+            downloaderName,
+            query,
+            TimeSpan.FromMinutes(60),
+            null,
+            null,
+            TestClock.UtcNow);
 }

--- a/Octans.Tests/Infrastructure/OctansClientTests.cs
+++ b/Octans.Tests/Infrastructure/OctansClientTests.cs
@@ -1,8 +1,10 @@
+using System.Net;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Octans.Client;
 using Octans.Core.Importing;
 using Octans.Data.Models;
+using Octans.Data.Models.Duplicates;
 
 namespace Octans.Tests.Infrastructure;
 
@@ -146,5 +148,130 @@ public class OctansClientTests
         result
             .Should()
             .Be(new ImportJobClientResult(jobId, $"/import-jobs/{jobId}"));
+    }
+
+    [Fact]
+    public async Task ScanDuplicatesAsync_PostsToEndpoint()
+    {
+        HttpRequestMessage? observedRequest = null;
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            observedRequest = request;
+
+            return StubHttpResponses.Json("""{"perceptualHashesCalculated":2,"candidatesCreated":1}""");
+        });
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://octans.test")
+        };
+
+        var client = new OctansClient(httpClient);
+
+        var result = await client.ScanDuplicatesAsync();
+
+        observedRequest
+            .Should()
+            .NotBeNull();
+
+        observedRequest!
+            .Method
+            .Should()
+            .Be(HttpMethod.Post);
+
+        observedRequest
+            .RequestUri
+            .Should()
+            .Be(new Uri("https://octans.test/duplicates/scan"));
+
+        result
+            .Should()
+            .Be(new DuplicateScanResultDto(2, 1));
+    }
+
+    [Fact]
+    public async Task GetDuplicateCandidatesAsync_GetsCandidatesEndpoint()
+    {
+        HttpRequestMessage? observedRequest = null;
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            observedRequest = request;
+
+            return StubHttpResponses.Json(
+                """
+                [{"id":5,"hashId1":7,"hash1":"AAAA","mediaUrl1":"/media/AAAA","hashId2":8,"hash2":"BBBB","mediaUrl2":"/media/BBBB","distance":4}]
+                """);
+        });
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://octans.test")
+        };
+
+        var client = new OctansClient(httpClient);
+
+        var candidates = await client.GetDuplicateCandidatesAsync();
+
+        observedRequest
+            .Should()
+            .NotBeNull();
+
+        observedRequest!
+            .Method
+            .Should()
+            .Be(HttpMethod.Get);
+
+        observedRequest
+            .RequestUri
+            .Should()
+            .Be(new Uri("https://octans.test/duplicates/candidates"));
+
+        candidates
+            .Should()
+            .ContainSingle()
+            .Which
+            .Should()
+            .Be(new DuplicateCandidateDto(5, 7, "AAAA", "/media/AAAA", 8, "BBBB", "/media/BBBB", 4));
+    }
+
+    [Fact]
+    public async Task ResolveDuplicateCandidateAsync_PostsResolution()
+    {
+        HttpRequestMessage? observedRequest = null;
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            observedRequest = request;
+
+            return new(HttpStatusCode.NoContent);
+        });
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://octans.test")
+        };
+
+        var client = new OctansClient(httpClient);
+
+        await client.ResolveDuplicateCandidateAsync(5, DuplicateResolution.KeepBoth, 7);
+
+        observedRequest
+            .Should()
+            .NotBeNull();
+
+        observedRequest!
+            .Method
+            .Should()
+            .Be(HttpMethod.Post);
+
+        observedRequest
+            .RequestUri
+            .Should()
+            .Be(new Uri("https://octans.test/duplicates/candidates/5/resolution"));
+
+        var body = await observedRequest.Content!.ReadAsStringAsync();
+
+        body
+            .Should()
+            .Be("""{"resolution":"KeepBoth","keepHashId":7}""");
     }
 }

--- a/Octans.Tests/Viewmodels/DetailsPaneViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/DetailsPaneViewmodelTests.cs
@@ -1,9 +1,11 @@
 using MudBlazor;
 using NSubstitute;
+using Octans.Client;
 using Octans.Client.Components.Gallery;
 using Octans.Core.Notes;
 using Octans.Core.Repositories;
 using Octans.Core.Tags;
+using Octans.Data.Models;
 using Octans.Tests.Helpers;
 
 namespace Octans.Tests.Viewmodels;
@@ -12,25 +14,21 @@ public sealed class DetailsPaneViewmodelTests
 {
     private const string Hash = "DEADBEEF";
 
-    private readonly INoteService _noteService = Substitute.For<INoteService>();
-    private readonly ITagService _tagService = Substitute.For<ITagService>();
+    private readonly IOctansClient _client = Substitute.For<IOctansClient>();
     private readonly ISnackbar _snackbar = Substitute.For<ISnackbar>();
-    private readonly SpyChannelWriter<RepositoryChangeRequest> _repositoryChannel = new();
     private readonly DetailsPaneViewmodel _sut;
 
     public DetailsPaneViewmodelTests()
     {
-        _noteService.GetNotesAsync(Arg.Any<string>()).Returns([]);
-        _tagService.GetTagsForHashAsync(Arg.Any<string>()).Returns([]);
-        _sut = new(_noteService, _tagService, _snackbar, _repositoryChannel);
+        _client.GetMediaDetailsAsync(Arg.Any<string>()).Returns(EmptyDetails(Hash));
+        _sut = new(_snackbar, _client);
     }
 
     [Fact]
     public async Task SelectHashAsync_loads_notes_and_tags()
     {
         var note = new NoteDto(1, "hello", TestClock.UtcNow, TestClock.UtcNow);
-        _noteService.GetNotesAsync(Hash).Returns([note]);
-        _tagService.GetTagsForHashAsync(Hash).Returns([new("artist", "someone")]);
+        _client.GetMediaDetailsAsync(Hash).Returns(Details(Hash, [note], [new("artist", "someone")]));
 
         await _sut.SelectHashAsync(Hash);
 
@@ -45,8 +43,10 @@ public sealed class DetailsPaneViewmodelTests
     [Fact]
     public async Task SelectHashAsync_clears_state_when_selection_is_empty()
     {
-        _noteService.GetNotesAsync(Hash).Returns([new NoteDto(1, "hello", TestClock.UtcNow, TestClock.UtcNow)]);
-        _tagService.GetTagsForHashAsync(Hash).Returns([new("artist", "someone")]);
+        _client.GetMediaDetailsAsync(Hash).Returns(Details(
+            Hash,
+            [new NoteDto(1, "hello", TestClock.UtcNow, TestClock.UtcNow)],
+            [new("artist", "someone")]));
         await _sut.SelectHashAsync(Hash);
         _sut.NewNoteContent = "draft";
 
@@ -66,16 +66,18 @@ public sealed class DetailsPaneViewmodelTests
 
         await _sut.ArchiveImage();
 
-        var item = Assert.Single(_repositoryChannel.WrittenItems);
-        Assert.Equal(Hash, item.Hash);
-        Assert.Equal(RepositoryDestination.Archive, item.Destination);
+        await _client
+            .Received(1)
+            .TransitionRepositoryItemsAsync(
+                Arg.Is<IEnumerable<string>>(hashes => hashes.SequenceEqual(new[] { Hash })),
+                RepositoryDestination.Archive);
     }
 
     [Fact]
     public async Task AddNote_appends_note_and_clears_input()
     {
         var note = new NoteDto(3, "saved", TestClock.UtcNow, TestClock.UtcNow);
-        _noteService.AddNoteAsync(Hash, "saved").Returns(note);
+        _client.AddNoteAsync(Hash, "saved").Returns(note);
         await _sut.SelectHashAsync(Hash);
         _sut.NewNoteContent = "saved";
 
@@ -89,20 +91,20 @@ public sealed class DetailsPaneViewmodelTests
     public async Task DeleteNote_removes_note()
     {
         var note = new NoteDto(3, "saved", TestClock.UtcNow, TestClock.UtcNow);
-        _noteService.GetNotesAsync(Hash).Returns([note]);
+        _client.GetMediaDetailsAsync(Hash).Returns(Details(Hash, [note], []));
         await _sut.SelectHashAsync(Hash);
 
         await _sut.DeleteNote(note);
 
         Assert.Empty(_sut.Notes);
-        await _noteService.Received(1).DeleteNoteAsync(note.Id);
+        await _client.Received(1).DeleteNoteAsync(note.Id);
     }
 
     [Fact]
     public async Task Mutations_raise_state_changed()
     {
         var note = new NoteDto(3, "saved", TestClock.UtcNow, TestClock.UtcNow);
-        _noteService.AddNoteAsync(Hash, "saved").Returns(note);
+        _client.AddNoteAsync(Hash, "saved").Returns(note);
         await _sut.SelectHashAsync(Hash);
         _sut.NewNoteContent = "saved";
         var callCount = 0;
@@ -116,4 +118,12 @@ public sealed class DetailsPaneViewmodelTests
 
         Assert.Equal(1, callCount);
     }
+
+    private static MediaDetailsDto EmptyDetails(string hash) => Details(hash, [], []);
+
+    private static MediaDetailsDto Details(
+        string hash,
+        IReadOnlyList<NoteDto> notes,
+        IReadOnlyList<TagModel> tags) =>
+        new(1, hash, ".jpg", "image/jpeg", RepositoryType.Inbox, tags, notes, $"/media/{hash}");
 }

--- a/Octans.Tests/Viewmodels/DownloadsViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/DownloadsViewmodelTests.cs
@@ -1,6 +1,6 @@
 using NSubstitute;
+using Octans.Client;
 using Octans.Client.Components.Downloads;
-using Octans.Core.Http;
 using Octans.Core.Http.Models;
 using Octans.Data.Models;
 using Octans.Tests.Helpers;
@@ -9,19 +9,19 @@ namespace Octans.Tests.Viewmodels;
 
 public class DownloadsViewmodelTests
 {
-    private readonly IDownloadStateService _stateService = Substitute.For<IDownloadStateService>();
+    private readonly IOctansClient _client = Substitute.For<IOctansClient>();
     private readonly DownloadsViewmodel _sut;
 
     public DownloadsViewmodelTests()
     {
-        _sut = new(_stateService);
+        _sut = new(_client);
     }
 
     [Fact]
     public async Task InitializeAsync_populates_active_downloads()
     {
         var status = CreateStatus();
-        _stateService.GetAllDownloads().Returns(new List<DownloadStatus> { status });
+        _client.GetDownloadsAsync().Returns([status]);
 
         await _sut.InitializeAsync();
 
@@ -30,10 +30,10 @@ public class DownloadsViewmodelTests
     }
 
     [Fact]
-    public async Task HandleDownloadsChanged_refreshes_and_raises_event()
+    public async Task RefreshAsync_refreshes_and_raises_event()
     {
         var status = CreateStatus();
-        _stateService.GetAllDownloads().Returns(new List<DownloadStatus> { status });
+        _client.GetDownloadsAsync().Returns([status]);
 
         var triggered = false;
         _sut.StateChanged += () =>
@@ -42,69 +42,38 @@ public class DownloadsViewmodelTests
             return Task.CompletedTask;
         };
 
-        await _sut.Handle(new DownloadsChanged { ChangeType = DownloadChangeType.Added });
+        await _sut.RefreshAsync();
 
         Assert.True(triggered);
         Assert.Single(_sut.ActiveDownloads);
         Assert.Equal(status.Id, _sut.ActiveDownloads[0].Id);
     }
 
-    [Fact]
-    public async Task HandleDownloadStatusChanged_updates_existing_and_raises_event()
-    {
-        var id = Guid.NewGuid();
-        var existing = CreateStatus(id, bytesDownloaded: 10);
-        _stateService.GetAllDownloads().Returns(new List<DownloadStatus> { existing });
-        await _sut.InitializeAsync();
-
-        var updated = CreateStatus(id, bytesDownloaded: 50);
-
-        var triggered = false;
-        _sut.StateChanged += () =>
-        {
-            triggered = true;
-            return Task.CompletedTask;
-        };
-
-        await _sut.Handle(new DownloadStatusChanged { Status = updated });
-
-        Assert.True(triggered);
-        Assert.Single(_sut.ActiveDownloads);
-        Assert.Equal(50, _sut.ActiveDownloads[0].BytesDownloaded);
-    }
-
-    [Fact]
-    public async Task HandleDownloadStatusChanged_adds_new_download_and_raises_event()
-    {
-        var status = CreateStatus();
-        var triggered = false;
-        _sut.StateChanged += () =>
-        {
-            triggered = true;
-            return Task.CompletedTask;
-        };
-
-        await _sut.Handle(new DownloadStatusChanged { Status = status });
-
-        Assert.True(triggered);
-        Assert.Single(_sut.ActiveDownloads);
-        Assert.Equal(status.Id, _sut.ActiveDownloads[0].Id);
-    }
-
-    private static DownloadStatus CreateStatus(Guid? id = null, long bytesDownloaded = 0)
-    {
-        return new DownloadStatus
-        {
-            Id = id ?? Guid.NewGuid(),
-            Url = "https://example.com/file.zip",
-            Filename = "file.zip",
-            DestinationPath = "/downloads/file.zip",
-            Domain = "example.com",
-            TotalBytes = 100,
-            BytesDownloaded = bytesDownloaded,
-            State = DownloadState.InProgress,
-            CreatedAt = TestClock.UtcNow,
-            LastUpdated = TestClock.UtcNow
-        };
-    }
+    private static DownloadStatusDto CreateStatus(Guid? id = null, long bytesDownloaded = 0) => new(
+        id ?? Guid.NewGuid(),
+        "https://example.com/file.zip",
+        "file.zip",
+        null,
+        "/downloads/file.zip",
+        "example.com",
+        0,
+        100,
+        bytesDownloaded,
+        bytesDownloaded,
+        0,
+        DownloadState.InProgress,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        TestClock.UtcNow,
+        null,
+        null,
+        TestClock.UtcNow);
 }

--- a/Octans.Tests/Viewmodels/DuplicateManagerViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/DuplicateManagerViewmodelTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor;
+using NSubstitute;
+using Octans.Client;
+using Octans.Client.Components.Duplicates;
+using Octans.Data.Models.Duplicates;
+
+using ApiDuplicateCandidateDto = Octans.Client.DuplicateCandidateDto;
+
+namespace Octans.Tests.Viewmodels;
+
+public sealed class DuplicateManagerViewmodelTests
+{
+    private readonly IOctansClient _octansClient = Substitute.For<IOctansClient>();
+    private readonly ISnackbar _snackbar = Substitute.For<ISnackbar>();
+    private readonly DuplicateManagerViewmodel _sut;
+
+    public DuplicateManagerViewmodelTests()
+    {
+        _octansClient
+            .GetDuplicateCandidatesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ApiDuplicateCandidateDto>>([]));
+
+        _sut = new(_octansClient, _snackbar, NullLogger<DuplicateManagerViewmodel>.Instance);
+    }
+
+    [Fact]
+    public async Task Initialize_LoadsCandidatesFromApiClient()
+    {
+        _octansClient
+            .GetDuplicateCandidatesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ApiDuplicateCandidateDto>>([
+                new(1, 11, "AAAA", "/media/AAAA", 12, "BBBB", "/media/BBBB", 3),
+                new(2, 21, "CCCC", "/media/CCCC", 22, "DDDD", "/media/DDDD", 8)
+            ]));
+
+        await _sut.Initialize();
+
+        Assert.False(_sut.IsLoading);
+        Assert.Equal([2, 1], _sut.Candidates.Select(c => c.Id));
+        Assert.Equal("/media/CCCC", _sut.Candidates[0].Url1);
+        Assert.Equal("/media/DDDD", _sut.Candidates[0].Url2);
+    }
+
+    [Fact]
+    public async Task TriggerCheck_ScansThenReloadsCandidates()
+    {
+        _octansClient
+            .ScanDuplicatesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new DuplicateScanResultDto(2, 1)));
+
+        _octansClient
+            .GetDuplicateCandidatesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ApiDuplicateCandidateDto>>([
+                new(1, 11, "AAAA", "/media/AAAA", 12, "BBBB", "/media/BBBB", 3)
+            ]));
+
+        await _sut.TriggerCheck();
+
+        Assert.False(_sut.IsCalculating);
+        await _octansClient
+            .Received(1)
+            .ScanDuplicatesAsync(Arg.Any<CancellationToken>());
+        Assert.Single(_sut.Candidates);
+    }
+
+    [Fact]
+    public async Task Resolve_SendsApiResolutionAndReloads()
+    {
+        _octansClient
+            .GetDuplicateCandidatesAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<IReadOnlyList<ApiDuplicateCandidateDto>>([
+                    new(5, 11, "AAAA", "/media/AAAA", 12, "BBBB", "/media/BBBB", 3)
+                ]),
+                Task.FromResult<IReadOnlyList<ApiDuplicateCandidateDto>>([]));
+
+        await _sut.Initialize();
+
+        await _sut.Resolve(5, DuplicateCandidateResolution.KeepBoth, 11);
+
+        await _octansClient
+            .Received(1)
+            .ResolveDuplicateCandidateAsync(
+                5,
+                DuplicateResolution.KeepBoth,
+                11,
+                Arg.Any<CancellationToken>());
+        Assert.Empty(_sut.Candidates);
+    }
+}

--- a/Octans.Tests/Viewmodels/GalleryViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/GalleryViewmodelTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Octans.Client;
@@ -9,17 +8,15 @@ using Octans.Core.Querying;
 using Octans.Core.Repositories;
 using Octans.Core.Scripting;
 using Octans.Data.Models;
-using Octans.Tests.Helpers;
 
 namespace Octans.Tests.Viewmodels;
 
 public class GalleryViewmodelTests
 {
-    private readonly IQueryService _service;
+    private readonly IOctansClient _client;
     private readonly GalleryViewmodel _sut;
     private readonly IBrowserStorage _storage = Substitute.For<IBrowserStorage>();
     private readonly IClipboardService _clipboard = Substitute.For<IClipboardService>();
-    private readonly SpyChannelWriter<RepositoryChangeRequest> _repoChannel = new();
     private readonly ICustomCommandProvider _commandProvider = Substitute.For<ICustomCommandProvider>();
     private readonly IBrowserService _browserService = Substitute.For<IBrowserService>();
     private readonly StatusService _status = new();
@@ -29,16 +26,18 @@ public class GalleryViewmodelTests
         "/media/DEADBEEF", "/media/01234567"
     ];
 
+    private static readonly string[] DeadbeefHash = ["DEADBEEF"];
+    private static readonly string[] NumericHash = ["01234567"];
+
     public GalleryViewmodelTests()
     {
-        _service = Substitute.For<IQueryService>();
+        _client = Substitute.For<IOctansClient>();
 
-        _sut = new(_service,
+        _sut = new(_client,
             _storage,
             _clipboard,
             _status,
             _commandProvider,
-            _repoChannel,
             _browserService,
             NullLogger<GalleryViewmodel>.Instance);
     }
@@ -66,13 +65,13 @@ public class GalleryViewmodelTests
             }
         };
 
-        _service
-            .CountAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+        _client
+            .CountQueryFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(hashes.Length);
 
-        _service
-            .Query(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
-            .Returns(_ => ReturnAsync(hashes));
+        _client
+            .QueryFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(hashes);
 
         var args = new List<QueryParameter>();
 
@@ -88,13 +87,17 @@ public class GalleryViewmodelTests
     {
         var total = 100;
 
-        _service
-            .CountAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+        _client
+            .CountQueryFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(total);
 
-        _service
-            .Query(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
-            .Returns(ci => SlowStream(total, ci.Arg<CancellationToken>()));
+        _client
+            .QueryFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(async ci =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30), ci.Arg<CancellationToken>());
+                return [];
+            });
 
         var args = new List<QueryParameter>();
 
@@ -113,8 +116,8 @@ public class GalleryViewmodelTests
     [Fact]
     public async Task Exception_sets_LastError_and_stops_searching()
     {
-        _service
-            .CountAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+        _client
+            .CountQueryFilesAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns<Task<int>>(_ => throw new InvalidOperationException("boom"));
 
         var args = new List<QueryParameter>();
@@ -139,15 +142,16 @@ public class GalleryViewmodelTests
 
         await _sut.OnFilterComplete(result);
 
-        var items = new List<RepositoryChangeRequest>();
-
-        while (_repoChannel.Channel.Reader.TryRead(out var item))
-        {
-            items.Add(item);
-        }
-
-        Assert.Contains(items, r => r is { Hash: "DEADBEEF", Destination: RepositoryDestination.Archive });
-        Assert.Contains(items, r => r is { Hash: "01234567", Destination: RepositoryDestination.Trash });
+        await _client
+            .Received(1)
+            .TransitionRepositoryItemsAsync(
+                Arg.Is<IEnumerable<string>>(hashes => hashes.SequenceEqual(DeadbeefHash)),
+                RepositoryDestination.Archive);
+        await _client
+            .Received(1)
+            .TransitionRepositoryItemsAsync(
+                Arg.Is<IEnumerable<string>>(hashes => hashes.SequenceEqual(NumericHash)),
+                RepositoryDestination.Trash);
     }
 
     [Fact]
@@ -191,9 +195,11 @@ public class GalleryViewmodelTests
 
         Assert.DoesNotContain(Expected[0], _sut.ImageUrls);
 
-        Assert.True(_repoChannel.Channel.Reader.TryRead(out var item));
-        Assert.Equal("DEADBEEF", item.Hash);
-        Assert.Equal(RepositoryDestination.Trash, item.Destination);
+        await _client
+            .Received(1)
+            .TransitionRepositoryItemsAsync(
+                Arg.Is<IEnumerable<string>>(hashes => hashes.SequenceEqual(DeadbeefHash)),
+                RepositoryDestination.Trash);
     }
 
     [Fact]
@@ -217,37 +223,4 @@ public class GalleryViewmodelTests
         Assert.Equal("Copied 2 URL(s)", _status.GenericText);
     }
 
-    private static async IAsyncEnumerable<HashItem> ReturnAsync(IEnumerable<HashItem> items)
-    {
-        foreach (var item in items)
-        {
-            await Task.Yield();
-
-            yield return item;
-        }
-    }
-
-    private static async IAsyncEnumerable<HashItem> SlowStream(int count,
-        [EnumeratorCancellation] CancellationToken token)
-    {
-        for (var i = 0; i < count; i++)
-        {
-            token.ThrowIfCancellationRequested();
-
-            await Task.Delay(10, token);
-
-            var hash = BitConverter.GetBytes(i);
-
-            if (BitConverter.IsLittleEndian)
-            {
-                Array.Reverse(hash);
-            }
-
-            yield return new()
-            {
-                Id = i,
-                Hash = hash
-            };
-        }
-    }
 }

--- a/Octans.Tests/Viewmodels/ImageViewerViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/ImageViewerViewmodelTests.cs
@@ -1,28 +1,32 @@
 using Microsoft.AspNetCore.Components.Web;
 using NSubstitute;
+using Octans.Client;
 using Octans.Client.Components.Gallery;
 using Octans.Client.Services;
 using Octans.Client.Settings;
+using Octans.Core.Notes;
+using Octans.Core.Repositories;
 using Octans.Core.Tags;
+using Octans.Data.Models;
 
 namespace Octans.Tests.Viewmodels;
 
 public sealed class ImageViewerViewmodelTests
 {
-    private readonly ITagService _tagService = Substitute.For<ITagService>();
+    private readonly IOctansClient _client = Substitute.For<IOctansClient>();
     private readonly IKeybindingService _keybindingService = Substitute.For<IKeybindingService>();
     private readonly ImageViewerViewmodel _sut;
 
     public ImageViewerViewmodelTests()
     {
-        _tagService.GetTagsForHashAsync(Arg.Any<string>()).Returns([]);
-        _sut = new(_tagService, _keybindingService);
+        _client.GetMediaDetailsAsync(Arg.Any<string>()).Returns(Details("DEADBEEF", []));
+        _sut = new(_client, _keybindingService);
     }
 
     [Fact]
     public async Task InitializeAsync_loads_tags_for_current_media_hash()
     {
-        _tagService.GetTagsForHashAsync("DEADBEEF").Returns([new("artist", "someone")]);
+        _client.GetMediaDetailsAsync("DEADBEEF").Returns(Details("DEADBEEF", [new("artist", "someone")]));
 
         await _sut.InitializeAsync(["/media/DEADBEEF.jpg?width=200"], null, filterMode: false);
 
@@ -81,4 +85,14 @@ public sealed class ImageViewerViewmodelTests
 
         Assert.True(action.CloseRequested);
     }
+
+    private static MediaDetailsDto Details(string hash, IReadOnlyList<TagModel> tags) => new(
+        1,
+        hash,
+        ".jpg",
+        "image/jpeg",
+        RepositoryType.Inbox,
+        tags,
+        Array.Empty<NoteDto>(),
+        $"/media/{hash}");
 }

--- a/Octans.Tests/Viewmodels/LocalFileImportViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/LocalFileImportViewmodelTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Octans.Client;
 using Octans.Client.Components.Importing;
 using Octans.Core.Importing;
 
@@ -10,22 +11,22 @@ namespace Octans.Tests.Viewmodels;
 
 public class LocalFileImportViewmodelTests
 {
-    private readonly IImportJobService _importJobService;
+    private readonly IOctansClient _client;
     private readonly LocalFileImportViewmodel _sut;
 
     public LocalFileImportViewmodelTests()
     {
         MockFileSystem fs = new();
         var env = Substitute.For<IWebHostEnvironment>();
-        _importJobService = Substitute.For<IImportJobService>();
-        _importJobService
-            .Create(Arg.Any<ImportJobCreateRequest>())
-            .Returns(Task.FromResult(new ImportJobCreatedDto(Guid.NewGuid())));
+        _client = Substitute.For<IOctansClient>();
+        _client
+            .CreateImportJobAsync(Arg.Any<ImportJobCreateRequest>())
+            .Returns(Task.FromResult(new ImportJobClientResult(Guid.NewGuid(), "/import-jobs/test")));
 
         // This has to be a root path to avoid the URI ctor breaking.
         env.WebRootPath.Returns("/wwwroot");
 
-        _sut = new(fs, env, _importJobService, NullLogger<LocalFileImportViewmodel>.Instance);
+        _sut = new(fs, env, _client, NullLogger<LocalFileImportViewmodel>.Instance);
     }
 
     [Fact]
@@ -59,9 +60,9 @@ public class LocalFileImportViewmodelTests
 
         await _sut.SendLocalFilesToServer();
 
-        await _importJobService
+        await _client
             .Received(1)
-            .Create(Arg.Is<ImportJobCreateRequest>(r =>
+            .CreateImportJobAsync(Arg.Is<ImportJobCreateRequest>(r =>
                 r.ImportType == ImportType.File && r.DeleteAfterImport == false && r.Sources.Count == 2));
 
         Assert.Empty(_sut.LocalFiles);
@@ -74,8 +75,8 @@ public class LocalFileImportViewmodelTests
 
         await _sut.SendLocalFilesToServer();
 
-        await _importJobService
+        await _client
             .DidNotReceive()
-            .Create(Arg.Any<ImportJobCreateRequest>());
+            .CreateImportJobAsync(Arg.Any<ImportJobCreateRequest>());
     }
 }

--- a/Octans.Tests/Viewmodels/QueryBuilderViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/QueryBuilderViewmodelTests.cs
@@ -1,55 +1,27 @@
 using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Octans.Client;
 using Octans.Client.Components.Gallery;
-using Octans.Core.Querying;
 using Octans.Core.Tags;
-using Octans.Data.Models;
-using Octans.Data.Models.Tagging;
-using Octans.Tests.Helpers;
 
 namespace Octans.Tests.Viewmodels;
 
-public class QueryBuilderViewmodelTests : IAsyncLifetime, IClassFixture<DatabaseFixture>
+public class QueryBuilderViewmodelTests
 {
-    private readonly ServiceProvider _provider;
+    private readonly IOctansClient _client = Substitute.For<IOctansClient>();
     private readonly QueryBuilderViewmodel _sut;
-    private readonly ServerDbContext _context;
 
-    public QueryBuilderViewmodelTests(DatabaseFixture fixture)
+    public QueryBuilderViewmodelTests()
     {
-        var services = new ServiceCollection();
-        fixture.RegisterDbContext(services);
-
-        services.AddScoped<TagSplitter>();
-        services.AddScoped<QuerySuggestionFinder>();
-        services.AddScoped<QueryBuilderViewmodel>();
-
-        _provider = services.BuildServiceProvider();
-        _context = _provider.GetRequiredService<ServerDbContext>();
-        _sut = _provider.GetRequiredService<QueryBuilderViewmodel>();
-    }
-
-    public async Task InitializeAsync()
-    {
-        await DatabaseFixture.ResetAsync(_provider);
-    }
-
-    public Task DisposeAsync()
-    {
-        _sut.Dispose();
-        return Task.CompletedTask;
+        _sut = new(_client);
     }
 
     [Fact]
     public async Task OnInputAsync_ShouldPopulateSuggestions()
     {
-        // Arrange
-        var ns = new Namespace { Value = "character" };
-        var t1 = new Tag { Namespace = ns, Subtag = new Subtag { Value = "goku" } };
-
-        await _context.Namespaces.AddAsync(ns);
-        await _context.Tags.AddAsync(t1);
-        await _context.SaveChangesAsync();
+        _client
+            .GetQuerySuggestionsAsync("go", cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([new TagModel("character", "goku")]);
 
         var stateChanged = false;
         _sut.StateChanged += () =>
@@ -58,34 +30,24 @@ public class QueryBuilderViewmodelTests : IAsyncLifetime, IClassFixture<Database
             return Task.CompletedTask;
         };
 
-        // Act
-        // Use a short debounce for testing
         await _sut.OnInputAsync("go", debounceMs: 10);
 
-        // Assert
         stateChanged.Should().BeTrue();
-        _sut.Suggestions.Should().Contain(s => s.Namespace == t1.Namespace.Value && s.Subtag == t1.Subtag.Value);
+        _sut.Suggestions.Should().Contain(s => s.Namespace == "character" && s.Subtag == "goku");
     }
 
     [Fact]
     public async Task OnInputAsync_ShouldClearSuggestions_WhenInputIsEmpty()
     {
-        // Arrange
-        var ns = new Namespace { Value = "character" };
-        var t1 = new Tag { Namespace = ns, Subtag = new Subtag { Value = "goku" } };
+        _client
+            .GetQuerySuggestionsAsync("go", cancellationToken: Arg.Any<CancellationToken>())
+            .Returns([new TagModel("character", "goku")]);
 
-        await _context.Namespaces.AddAsync(ns);
-        await _context.Tags.AddAsync(t1);
-        await _context.SaveChangesAsync();
-
-        // Populate first
         await _sut.OnInputAsync("go", debounceMs: 10);
         _sut.Suggestions.Should().NotBeEmpty();
 
-        // Act
         await _sut.OnInputAsync("", debounceMs: 10);
 
-        // Assert
         _sut.Suggestions.Should().BeEmpty();
     }
 }

--- a/Octans.Tests/Viewmodels/RawUrlImportViewmodelTests.cs
+++ b/Octans.Tests/Viewmodels/RawUrlImportViewmodelTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Octans.Client;
 using Octans.Client.Components.Importing;
 using Octans.Core.Importing;
 
@@ -7,20 +8,20 @@ namespace Octans.Tests.Viewmodels;
 
 public class RawUrlImportViewmodelTests
 {
-    private readonly IImportJobService _importJobService;
+    private readonly IOctansClient _client;
     private readonly RawUrlImportViewmodel _sut;
 
     public RawUrlImportViewmodelTests()
     {
-        _importJobService = Substitute.For<IImportJobService>();
+        _client = Substitute.For<IOctansClient>();
 
-        var created = new ImportJobCreatedDto(Guid.NewGuid());
+        var created = new ImportJobClientResult(Guid.NewGuid(), "/import-jobs/test");
 
-        _importJobService
-            .Create(Arg.Any<ImportJobCreateRequest>())
+        _client
+            .CreateImportJobAsync(Arg.Any<ImportJobCreateRequest>())
             .Returns(Task.FromResult(created));
 
-        _sut = new(_importJobService, NullLogger<RawUrlImportViewmodel>.Instance);
+        _sut = new(_client, NullLogger<RawUrlImportViewmodel>.Instance);
     }
 
     [Fact]
@@ -31,9 +32,9 @@ public class RawUrlImportViewmodelTests
 
         await _sut.SendUrlsToServer();
 
-        await _importJobService
+        await _client
             .Received(1)
-            .Create(Arg.Is<ImportJobCreateRequest>(r =>
+            .CreateImportJobAsync(Arg.Is<ImportJobCreateRequest>(r =>
                 r.ImportType == ImportType.RawUrl && r.DeleteAfterImport == false && r.AllowReimportDeleted &&
                 r.Sources.Count == 2));
 
@@ -47,8 +48,8 @@ public class RawUrlImportViewmodelTests
 
         await _sut.SendUrlsToServer();
 
-        await _importJobService
+        await _client
             .DidNotReceive()
-            .Create(Arg.Any<ImportJobCreateRequest>());
+            .CreateImportJobAsync(Arg.Any<ImportJobCreateRequest>());
     }
 }

--- a/docs/API-backed UI migration.md
+++ b/docs/API-backed UI migration.md
@@ -9,24 +9,18 @@ endpoints and then through `IOctansClient`.
 
 - Duplicate review: `DuplicateManagerViewmodel` uses `IOctansClient` for scanning, listing candidates,
   and resolving candidates. It no longer injects `ServerDbContext` or `DuplicateService`.
+- Gallery search and repository transitions run through `IOctansClient`.
+- Details pane tag/note reads, note mutation, and repository transitions run through `IOctansClient`.
+- Query builder suggestions run through `IOctansClient`.
+- Local file import still writes uploaded files under the UI host, which is a UI-host concern until there is
+  a real upload endpoint. Durable import job creation runs through `IOctansClient`.
+- Raw URL import job creation runs through `IOctansClient`.
+- Import job listing and lifecycle actions run through `IOctansClient`.
+- Subscription listing, creation, and deletion run through `IOctansClient`.
+- Download status reads run through `IOctansClient`.
+- Downloader listing and rescans run through `IOctansClient`.
 
 ## Remaining direct Core usage in `Octans.Client`
 
-These are not intended to be a public app contract. They are UI-host migration debt for issue #210 unless
-called out otherwise.
-
-- `GalleryViewmodel` still queries through `IQueryService` and queues repository transitions through the
-  in-process repository channel.
-- `DetailsPaneViewmodel` still reads tags/notes and queues archive/inbox transitions through Core services.
-- `QueryBuilderViewmodel` still calls `QuerySuggestionFinder` directly.
-- `LocalFileImportViewmodel` still writes uploaded files under the UI host before creating import jobs.
-  The file write is a UI-host concern until there is a real upload endpoint; the job creation should still
-  move through `IOctansClient`.
-- `RawUrlImportViewmodel` still creates import jobs through `IImportJobService`.
-- `ImportJobsPanel` still reads and mutates import jobs through `IImportJobService`.
-- `SubscriptionsViewmodel` still lists/adds/deletes subscriptions through `ISubscriptionService`.
-- `DownloadsViewmodel` still reads in-process download state through `IDownloadStateService`. The current
-  value is live UI refresh from host-local notifications; durable download reads should move through
-  `IOctansClient`.
 - `ServiceCollectionExtensions` still wires `ServerDbContext`, startup migration, and health checks. That is
   host infrastructure rather than ordinary UI workflow behavior.

--- a/docs/API-backed UI migration.md
+++ b/docs/API-backed UI migration.md
@@ -1,0 +1,32 @@
+# API-backed UI migration
+
+The REST API plus `IOctansClient` is the intended application contract for durable user workflows.
+Blazor viewmodels should keep UI-only state such as selection, dialog state, transient progress text,
+and browser/session storage. Workflows that should be externally testable should move behind API
+endpoints and then through `IOctansClient`.
+
+## Migrated
+
+- Duplicate review: `DuplicateManagerViewmodel` uses `IOctansClient` for scanning, listing candidates,
+  and resolving candidates. It no longer injects `ServerDbContext` or `DuplicateService`.
+
+## Remaining direct Core usage in `Octans.Client`
+
+These are not intended to be a public app contract. They are UI-host migration debt for issue #210 unless
+called out otherwise.
+
+- `GalleryViewmodel` still queries through `IQueryService` and queues repository transitions through the
+  in-process repository channel.
+- `DetailsPaneViewmodel` still reads tags/notes and queues archive/inbox transitions through Core services.
+- `QueryBuilderViewmodel` still calls `QuerySuggestionFinder` directly.
+- `LocalFileImportViewmodel` still writes uploaded files under the UI host before creating import jobs.
+  The file write is a UI-host concern until there is a real upload endpoint; the job creation should still
+  move through `IOctansClient`.
+- `RawUrlImportViewmodel` still creates import jobs through `IImportJobService`.
+- `ImportJobsPanel` still reads and mutates import jobs through `IImportJobService`.
+- `SubscriptionsViewmodel` still lists/adds/deletes subscriptions through `ISubscriptionService`.
+- `DownloadsViewmodel` still reads in-process download state through `IDownloadStateService`. The current
+  value is live UI refresh from host-local notifications; durable download reads should move through
+  `IOctansClient`.
+- `ServiceCollectionExtensions` still wires `ServerDbContext`, startup migration, and health checks. That is
+  host infrastructure rather than ordinary UI workflow behavior.


### PR DESCRIPTION
## Summary

- Add duplicate scan/list/resolve methods to `IOctansClient` for the existing duplicate REST endpoints.
- Move `DuplicateManagerViewmodel` off `ServerDbContext` and `DuplicateService`, keeping only UI state and snackbar handling in the viewmodel.
- Document the remaining direct Core usage in `Octans.Client` as #210 migration debt.

Refs #210.

## Validation

- `dotnet build`
- `dotnet test`